### PR TITLE
Add `cassetter convert` CLI for format conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,19 @@ cassetter is designed as a drop-in replacement. Most projects can migrate with m
 
 Existing VCR cassettes work as-is - cassetter reads both VCR format and its own format. On the next re-record, cassettes are written in cassetter's format with structured JSON bodies instead of escaped strings.
 
+To bulk-convert existing cassettes to a different format, use the CLI:
+
+```bash
+# Convert a single file
+cassetter convert cassette.yaml cassette.toml
+
+# Convert all cassettes in a directory (in-place, changing extension)
+cassetter convert tests/cassettes/ toml
+
+# Convert to a separate output directory
+cassetter convert tests/cassettes/ output/
+```
+
 ### pytest plugin
 
 cassetter uses the same `@pytest.mark.vcr` marker, `vcr_config` fixture, and `--record-mode` CLI flag. Key differences:

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ cassetter convert cassette.yaml cassette.toml
 cassetter convert tests/cassettes/ toml
 
 # Convert to a separate output directory
-cassetter convert tests/cassettes/ output/
+cassetter convert tests/cassettes/ output/ --to toml
 ```
 
 ### pytest plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ grpc = ["grpcio>=1.60"]
 websockets = ["websockets>=12.0"]
 pyreqwest = ["pyreqwest-impersonate>=0.5"]
 
+[project.scripts]
+cassetter = "cassetter.cli:main"
+
 [project.entry-points.pytest11]
 cassetter = "cassetter.pytest_plugin"
 

--- a/src/cassetter/cli.py
+++ b/src/cassetter/cli.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from cassetter._core import Cassette
+
+EXTENSIONS = {".yaml", ".yml", ".toml"}
+
+
+def convert_file(src: Path, dst: Path) -> int:
+    """Convert a single cassette file. Returns the number of interactions."""
+    cassette = Cassette.load(str(src))
+    cassette.save(str(dst))
+    return len(cassette)
+
+
+def convert(args: argparse.Namespace) -> None:
+    src = Path(args.input)
+    dst = Path(args.output)
+
+    if not src.exists():
+        print(f"error: {src} not found", file=sys.stderr)
+        sys.exit(1)
+
+    if src.is_dir():
+        convert_directory(src, dst, force=args.force)
+        return
+
+    if dst.exists() and not args.force:
+        print(f"error: {dst} already exists (use --force to overwrite)", file=sys.stderr)
+        sys.exit(1)
+
+    n = convert_file(src, dst)
+    print(f"Converted {n} interaction(s): {src} -> {dst}")
+
+
+def convert_directory(src_dir: Path, dst: Path, *, force: bool) -> None:
+    """Convert all cassette files in a directory tree.
+
+    *dst* is either an existing/new directory, or a bare extension like ``toml``
+    that determines the output format while keeping files in-place.
+    """
+    # Interpret dst as a target extension when it looks like one (no path separators, matches a known ext)
+    target_ext = None
+    if not dst.suffix and f".{dst}" in EXTENSIONS:
+        target_ext = f".{dst}"
+        out_dir = src_dir
+    elif dst.suffix in EXTENSIONS and len(dst.parts) == 1:
+        target_ext = dst.suffix
+        out_dir = src_dir
+    else:
+        out_dir = dst
+
+    sources = sorted(p for p in src_dir.rglob("*") if p.suffix in EXTENSIONS)
+    if not sources:
+        print(f"error: no cassette files found in {src_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    converted = 0
+    for src_file in sources:
+        rel = src_file.relative_to(src_dir)
+        if target_ext is not None:
+            dst_file = out_dir / rel.with_suffix(target_ext)
+        else:
+            dst_file = out_dir / rel
+
+        if src_file == dst_file:
+            continue
+
+        if dst_file.exists() and not force:
+            print(f"skip: {dst_file} already exists", file=sys.stderr)
+            continue
+
+        dst_file.parent.mkdir(parents=True, exist_ok=True)
+        n = convert_file(src_file, dst_file)
+        print(f"  {rel} -> {dst_file.relative_to(out_dir)} ({n} interaction(s))")
+        converted += 1
+
+    print(f"Converted {converted} file(s)")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="cassetter", description="Cassetter CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    convert_parser = subparsers.add_parser("convert", help="Convert cassettes between formats (yaml, toml)")
+    convert_parser.add_argument("input", help="Source cassette file or directory")
+    convert_parser.add_argument("output", help="Destination file, directory, or target format (e.g. 'toml')")
+    convert_parser.add_argument("--force", "-f", action="store_true", help="Overwrite existing files")
+
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.command == "convert":
+        convert(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cassetter/cli.py
+++ b/src/cassetter/cli.py
@@ -25,7 +25,8 @@ def convert(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     if src.is_dir():
-        convert_directory(src, dst, force=args.force)
+        to_ext = f".{args.to}" if args.to else None
+        convert_directory(src, dst, force=args.force, to_ext=to_ext)
         return
 
     if dst.exists() and not args.force:
@@ -36,19 +37,21 @@ def convert(args: argparse.Namespace) -> None:
     print(f"Converted {n} interaction(s): {src} -> {dst}")
 
 
-def convert_directory(src_dir: Path, dst: Path, *, force: bool) -> None:
+def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | None) -> None:
     """Convert all cassette files in a directory tree.
 
     *dst* is either an existing/new directory, or a bare extension like ``toml``
     that determines the output format while keeping files in-place.
+    *to_ext* overrides the target extension (e.g. ``.toml``) when writing to
+    a separate output directory.
     """
     # Interpret dst as a target extension when it looks like one (no path separators, matches a known ext)
-    target_ext = None
+    target_ext = to_ext
     if not dst.suffix and f".{dst}" in EXTENSIONS:
-        target_ext = f".{dst}"
+        target_ext = target_ext or f".{dst}"
         out_dir = src_dir
     elif dst.suffix in EXTENSIONS and len(dst.parts) == 1:
-        target_ext = dst.suffix
+        target_ext = target_ext or dst.suffix
         out_dir = src_dir
     else:
         out_dir = dst
@@ -89,6 +92,7 @@ def main(argv: list[str] | None = None) -> None:
     convert_parser.add_argument("input", help="Source cassette file or directory")
     convert_parser.add_argument("output", help="Destination file, directory, or target format (e.g. 'toml')")
     convert_parser.add_argument("--force", "-f", action="store_true", help="Overwrite existing files")
+    convert_parser.add_argument("--to", choices=["yaml", "toml"], help="Target format when output is a directory")
 
     args = parser.parse_args(argv)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from cassetter._core import Body, Cassette, HttpInteraction, HttpRequest, HttpResponse
+from cassetter.cli import main
+
+
+@pytest.fixture()
+def yaml_cassette(tmp_path: pytest.TempPathFactory) -> str:
+    path = str(tmp_path / "test.yaml")  # type: ignore[operator]
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "https://example.com/api"),
+            HttpResponse(200, body=Body("json", {"ok": True})),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(path)
+    return path
+
+
+def test_convert_yaml_to_toml(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
+    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+    main(["convert", yaml_cassette, dst])
+
+    loaded = Cassette.load(dst)
+    assert len(loaded) == 1
+    assert loaded.interactions[0].request.method == "GET"
+
+
+def test_convert_toml_to_yaml(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
+    toml_path = str(tmp_path / "intermediate.toml")  # type: ignore[operator]
+    main(["convert", yaml_cassette, toml_path])
+
+    yaml_path = str(tmp_path / "back.yaml")  # type: ignore[operator]
+    main(["convert", toml_path, yaml_path])
+
+    loaded = Cassette.load(yaml_path)
+    assert len(loaded) == 1
+    assert loaded.interactions[0].response.body.content == {"ok": True}
+
+
+def test_convert_refuses_overwrite(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
+    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+    main(["convert", yaml_cassette, dst])
+
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", yaml_cassette, dst])
+
+
+def test_convert_force_overwrite(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
+    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+    main(["convert", yaml_cassette, dst])
+    main(["convert", yaml_cassette, dst, "--force"])
+
+    loaded = Cassette.load(dst)
+    assert len(loaded) == 1
+
+
+def test_convert_missing_source(tmp_path: pytest.TempPathFactory) -> None:
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", str(tmp_path / "nope.yaml"), str(tmp_path / "out.toml")])  # type: ignore[operator]
+
+
+def test_convert_directory_to_format(tmp_path: pytest.TempPathFactory) -> None:
+    src_dir = tmp_path / "cassettes"  # type: ignore[operator]
+    src_dir.mkdir()
+    for name in ("a.yaml", "b.yaml"):
+        c = Cassette()
+        c.add_interaction(
+            HttpInteraction(
+                HttpRequest("GET", f"https://example.com/{name}"),
+                HttpResponse(200),
+                "2026-01-01T00:00:00Z",
+            )
+        )
+        c.save(str(src_dir / name))
+
+    main(["convert", str(src_dir), "toml"])
+
+    assert (src_dir / "a.toml").exists()
+    assert (src_dir / "b.toml").exists()
+    assert Cassette.load(str(src_dir / "a.toml")).interactions[0].request.uri == "https://example.com/a.yaml"
+
+
+def test_convert_directory_to_directory(tmp_path: pytest.TempPathFactory) -> None:
+    src_dir = tmp_path / "src"  # type: ignore[operator]
+    src_dir.mkdir()
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest("POST", "https://example.com/data"),
+            HttpResponse(201),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(str(src_dir / "test.yaml"))
+
+    out_dir = tmp_path / "dst"  # type: ignore[operator]
+    main(["convert", str(src_dir), str(out_dir), "--to", "toml"])
+
+    assert (out_dir / "test.toml").exists()
+    loaded = Cassette.load(str(out_dir / "test.toml"))
+    assert loaded.interactions[0].request.method == "POST"
+
+
+def test_convert_directory_skips_existing(tmp_path: pytest.TempPathFactory) -> None:
+    src_dir = tmp_path / "cassettes"  # type: ignore[operator]
+    src_dir.mkdir()
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "https://example.com"),
+            HttpResponse(200),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(str(src_dir / "test.yaml"))
+
+    main(["convert", str(src_dir), "toml"])
+    assert (src_dir / "test.toml").exists()
+
+    # Second run without --force should skip
+    main(["convert", str(src_dir), "toml"])
+
+
+def test_convert_no_command() -> None:
+    with pytest.raises(SystemExit, match="1"):
+        main([])
+
+
+def test_convert_empty_directory(tmp_path: pytest.TempPathFactory) -> None:
+    empty = tmp_path / "empty"  # type: ignore[operator]
+    empty.mkdir()
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", str(empty), "toml"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from cassetter._core import Body, Cassette, HttpInteraction, HttpRequest, HttpResponse
@@ -7,8 +9,8 @@ from cassetter.cli import main
 
 
 @pytest.fixture()
-def yaml_cassette(tmp_path: pytest.TempPathFactory) -> str:
-    path = str(tmp_path / "test.yaml")  # type: ignore[operator]
+def yaml_cassette(tmp_path: Path) -> str:
+    path = str(tmp_path / "test.yaml")
     c = Cassette()
     c.add_interaction(
         HttpInteraction(
@@ -21,8 +23,8 @@ def yaml_cassette(tmp_path: pytest.TempPathFactory) -> str:
     return path
 
 
-def test_convert_yaml_to_toml(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
-    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+def test_convert_yaml_to_toml(yaml_cassette: str, tmp_path: Path) -> None:
+    dst = str(tmp_path / "out.toml")
     main(["convert", yaml_cassette, dst])
 
     loaded = Cassette.load(dst)
@@ -30,11 +32,11 @@ def test_convert_yaml_to_toml(yaml_cassette: str, tmp_path: pytest.TempPathFacto
     assert loaded.interactions[0].request.method == "GET"
 
 
-def test_convert_toml_to_yaml(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
-    toml_path = str(tmp_path / "intermediate.toml")  # type: ignore[operator]
+def test_convert_toml_to_yaml(yaml_cassette: str, tmp_path: Path) -> None:
+    toml_path = str(tmp_path / "intermediate.toml")
     main(["convert", yaml_cassette, toml_path])
 
-    yaml_path = str(tmp_path / "back.yaml")  # type: ignore[operator]
+    yaml_path = str(tmp_path / "back.yaml")
     main(["convert", toml_path, yaml_path])
 
     loaded = Cassette.load(yaml_path)
@@ -42,16 +44,16 @@ def test_convert_toml_to_yaml(yaml_cassette: str, tmp_path: pytest.TempPathFacto
     assert loaded.interactions[0].response.body.content == {"ok": True}
 
 
-def test_convert_refuses_overwrite(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
-    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+def test_convert_refuses_overwrite(yaml_cassette: str, tmp_path: Path) -> None:
+    dst = str(tmp_path / "out.toml")
     main(["convert", yaml_cassette, dst])
 
     with pytest.raises(SystemExit, match="1"):
         main(["convert", yaml_cassette, dst])
 
 
-def test_convert_force_overwrite(yaml_cassette: str, tmp_path: pytest.TempPathFactory) -> None:
-    dst = str(tmp_path / "out.toml")  # type: ignore[operator]
+def test_convert_force_overwrite(yaml_cassette: str, tmp_path: Path) -> None:
+    dst = str(tmp_path / "out.toml")
     main(["convert", yaml_cassette, dst])
     main(["convert", yaml_cassette, dst, "--force"])
 
@@ -59,13 +61,13 @@ def test_convert_force_overwrite(yaml_cassette: str, tmp_path: pytest.TempPathFa
     assert len(loaded) == 1
 
 
-def test_convert_missing_source(tmp_path: pytest.TempPathFactory) -> None:
+def test_convert_missing_source(tmp_path: Path) -> None:
     with pytest.raises(SystemExit, match="1"):
-        main(["convert", str(tmp_path / "nope.yaml"), str(tmp_path / "out.toml")])  # type: ignore[operator]
+        main(["convert", str(tmp_path / "nope.yaml"), str(tmp_path / "out.toml")])
 
 
-def test_convert_directory_to_format(tmp_path: pytest.TempPathFactory) -> None:
-    src_dir = tmp_path / "cassettes"  # type: ignore[operator]
+def test_convert_directory_to_format(tmp_path: Path) -> None:
+    src_dir = tmp_path / "cassettes"
     src_dir.mkdir()
     for name in ("a.yaml", "b.yaml"):
         c = Cassette()
@@ -85,8 +87,8 @@ def test_convert_directory_to_format(tmp_path: pytest.TempPathFactory) -> None:
     assert Cassette.load(str(src_dir / "a.toml")).interactions[0].request.uri == "https://example.com/a.yaml"
 
 
-def test_convert_directory_to_directory(tmp_path: pytest.TempPathFactory) -> None:
-    src_dir = tmp_path / "src"  # type: ignore[operator]
+def test_convert_directory_to_directory(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src"
     src_dir.mkdir()
     c = Cassette()
     c.add_interaction(
@@ -98,7 +100,7 @@ def test_convert_directory_to_directory(tmp_path: pytest.TempPathFactory) -> Non
     )
     c.save(str(src_dir / "test.yaml"))
 
-    out_dir = tmp_path / "dst"  # type: ignore[operator]
+    out_dir = tmp_path / "dst"
     main(["convert", str(src_dir), str(out_dir), "--to", "toml"])
 
     assert (out_dir / "test.toml").exists()
@@ -106,8 +108,8 @@ def test_convert_directory_to_directory(tmp_path: pytest.TempPathFactory) -> Non
     assert loaded.interactions[0].request.method == "POST"
 
 
-def test_convert_directory_skips_existing(tmp_path: pytest.TempPathFactory) -> None:
-    src_dir = tmp_path / "cassettes"  # type: ignore[operator]
+def test_convert_directory_skips_existing(tmp_path: Path) -> None:
+    src_dir = tmp_path / "cassettes"
     src_dir.mkdir()
     c = Cassette()
     c.add_interaction(
@@ -131,8 +133,8 @@ def test_convert_no_command() -> None:
         main([])
 
 
-def test_convert_empty_directory(tmp_path: pytest.TempPathFactory) -> None:
-    empty = tmp_path / "empty"  # type: ignore[operator]
+def test_convert_empty_directory(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
     empty.mkdir()
     with pytest.raises(SystemExit, match="1"):
         main(["convert", str(empty), "toml"])


### PR DESCRIPTION
## Summary
- Add a `cassetter` CLI entry point with a `convert` subcommand
- Supports single file conversion: `cassetter convert cassette.yaml cassette.toml`
- Supports directory conversion: `cassetter convert cassettes/ toml` (converts all cassette files in-place, changing extension)
- Supports directory-to-directory: `cassetter convert cassettes/ output_dir/`
- `--force` / `-f` flag to overwrite existing files; without it, existing files are skipped

## Test plan
- [x] Single file YAML -> TOML conversion verified
- [x] Single file TOML -> YAML round-trip verified
- [x] Directory conversion verified (recursive, skips existing without `--force`)
- [x] Lint and type checks pass