### PR TITLE
Add CodSpeed benchmark CI integration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,26 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - run: uv run maturin develop --release
+      - uses: CodSpeedHQ/action@v3
+        with:
+          run: uv run pytest benchmarks/test_bench.py --codspeed

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,4 +23,5 @@ jobs:
       - run: uv run maturin develop --release
       - uses: CodSpeedHQ/action@v3
         with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
           run: uv run pytest benchmarks/test_bench.py --codspeed

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,5 +27,4 @@ jobs:
       - run: uv run maturin develop --release
       - uses: CodSpeedHQ/action@v3
         with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
           run: uv run pytest benchmarks/test_bench.py --codspeed

--- a/benchmarks/test_bench.py
+++ b/benchmarks/test_bench.py
@@ -1,0 +1,250 @@
+"""CodSpeed benchmarks for cassetter.
+
+Run locally: uv run pytest benchmarks/test_bench.py --codspeed
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+import pytest
+
+from cassetter._core import (
+    Body,
+    Cassette,
+    HttpInteraction,
+    HttpRequest,
+    HttpResponse,
+    MatchConfig,
+    SecurityConfig,
+    find_match,
+    scrub_interaction,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_cassette(n: int) -> Cassette:
+    c = Cassette()
+    for i in range(n):
+        c.add_interaction(
+            HttpInteraction(
+                request=HttpRequest(
+                    "POST",
+                    f"https://api.example.com/v1/items/{i}",
+                    {
+                        "accept": ["application/json"],
+                        "content-type": ["application/json"],
+                        "authorization": ["Bearer tok_abc123"],
+                        "x-request-id": [f"req-{i:06d}"],
+                    },
+                    Body("json", {"id": i, "name": f"item-{i}", "tags": ["a", "b", "c"]}),
+                ),
+                response=HttpResponse(
+                    200,
+                    {
+                        "content-type": ["application/json"],
+                        "x-request-id": [f"req-{i:06d}"],
+                        "cache-control": ["no-cache"],
+                    },
+                    Body(
+                        "json",
+                        {
+                            "id": i,
+                            "name": f"item-{i}",
+                            "tags": ["a", "b", "c"],
+                            "metadata": {"created": "2026-01-01", "version": 1},
+                        },
+                    ),
+                ),
+                recorded_at="2026-01-01T00:00:00Z",
+            )
+        )
+    return c
+
+
+@pytest.fixture(scope="module")
+def cassette_100() -> Cassette:
+    return _build_cassette(100)
+
+
+@pytest.fixture(scope="module")
+def cassette_1000() -> Cassette:
+    return _build_cassette(1000)
+
+
+@pytest.fixture(scope="module")
+def yaml_file_100(cassette_100: Cassette) -> str:
+    path = tempfile.mktemp(suffix=".yaml")
+    cassette_100.save(path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def yaml_file_1000(cassette_1000: Cassette) -> str:
+    path = tempfile.mktemp(suffix=".yaml")
+    cassette_1000.save(path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def toml_file_100(cassette_100: Cassette) -> str:
+    path = tempfile.mktemp(suffix=".toml")
+    cassette_100.save(path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def toml_file_1000(cassette_1000: Cassette) -> str:
+    path = tempfile.mktemp(suffix=".toml")
+    cassette_1000.save(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Load benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_load_yaml_100(yaml_file_100: str, benchmark: Any) -> None:
+    @benchmark
+    def _() -> None:
+        Cassette.load(yaml_file_100)
+
+
+@pytest.mark.benchmark
+def test_load_yaml_1000(yaml_file_1000: str, benchmark: Any) -> None:
+    @benchmark
+    def _() -> None:
+        Cassette.load(yaml_file_1000)
+
+
+@pytest.mark.benchmark
+def test_load_toml_100(toml_file_100: str, benchmark: Any) -> None:
+    @benchmark
+    def _() -> None:
+        Cassette.load(toml_file_100)
+
+
+@pytest.mark.benchmark
+def test_load_toml_1000(toml_file_1000: str, benchmark: Any) -> None:
+    @benchmark
+    def _() -> None:
+        Cassette.load(toml_file_1000)
+
+
+# ---------------------------------------------------------------------------
+# Save benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_save_yaml_100(cassette_100: Cassette, benchmark: Any) -> None:
+    path = tempfile.mktemp(suffix=".yaml")
+
+    @benchmark
+    def _() -> None:
+        cassette_100.save(path)
+
+
+@pytest.mark.benchmark
+def test_save_yaml_1000(cassette_1000: Cassette, benchmark: Any) -> None:
+    path = tempfile.mktemp(suffix=".yaml")
+
+    @benchmark
+    def _() -> None:
+        cassette_1000.save(path)
+
+
+@pytest.mark.benchmark
+def test_save_toml_100(cassette_100: Cassette, benchmark: Any) -> None:
+    path = tempfile.mktemp(suffix=".toml")
+
+    @benchmark
+    def _() -> None:
+        cassette_100.save(path)
+
+
+@pytest.mark.benchmark
+def test_save_toml_1000(cassette_1000: Cassette, benchmark: Any) -> None:
+    path = tempfile.mktemp(suffix=".toml")
+
+    @benchmark
+    def _() -> None:
+        cassette_1000.save(path)
+
+
+# ---------------------------------------------------------------------------
+# Match benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_match_first_100(cassette_100: Cassette, benchmark: Any) -> None:
+    interactions = cassette_100.interactions
+    played = [False] * len(interactions)
+    config = MatchConfig()
+    req = HttpRequest("POST", "https://api.example.com/v1/items/0")
+
+    @benchmark
+    def _() -> None:
+        find_match(req, interactions, played, config)
+
+
+@pytest.mark.benchmark
+def test_match_last_1000(cassette_1000: Cassette, benchmark: Any) -> None:
+    interactions = cassette_1000.interactions
+    played = [False] * len(interactions)
+    config = MatchConfig()
+    req = HttpRequest("POST", "https://api.example.com/v1/items/999")
+
+    @benchmark
+    def _() -> None:
+        find_match(req, interactions, played, config)
+
+
+@pytest.mark.benchmark
+def test_match_miss_1000(cassette_1000: Cassette, benchmark: Any) -> None:
+    interactions = cassette_1000.interactions
+    played = [False] * len(interactions)
+    config = MatchConfig()
+    req = HttpRequest("POST", "https://api.example.com/v1/items/99999")
+
+    @benchmark
+    def _() -> None:
+        try:
+            find_match(req, interactions, played, config)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Security scrub benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_scrub_interaction(benchmark: Any) -> None:
+    interaction = HttpInteraction(
+        request=HttpRequest(
+            "POST",
+            "https://api.example.com/v1/data?api_key=secret&format=json",
+            {"authorization": ["Bearer tok"], "content-type": ["application/json"]},
+            Body("json", {"password": "secret", "data": "hello"}),
+        ),
+        response=HttpResponse(
+            200,
+            {"set-cookie": ["session=abc"], "content-type": ["application/json"]},
+            Body("json", {"access_token": "tok_abc", "result": "ok"}),
+        ),
+        recorded_at="2026-01-01T00:00:00Z",
+    )
+    config = SecurityConfig()
+
+    @benchmark
+    def _() -> None:
+        scrub_interaction(interaction, config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "websockets>=12.0",
     "pyreqwest-impersonate>=0.5",
     "vcrpy>=8.1.1",
+    "pytest-codspeed>=3.2",
 ]
 
 [tool.ruff]
@@ -93,6 +94,7 @@ xfail_strict = true
 filterwarnings = ["error"]
 markers = [
     "vcr: Mark test to use VCR cassette recording/replay",
+    "benchmark: CodSpeed benchmark",
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -217,6 +217,7 @@ dev = [
     { name = "mypy" },
     { name = "pyreqwest-impersonate" },
     { name = "pytest" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -250,6 +251,7 @@ dev = [
     { name = "mypy", specifier = ">=1.8" },
     { name = "pyreqwest-impersonate", specifier = ">=0.5" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-codspeed", specifier = ">=3.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.28" },
@@ -1565,6 +1567,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/ab/eca41967d11c95392829a8b4bfa9220a51cffc4a33ec4653358000356918/pytest_codspeed-4.3.0.tar.gz", hash = "sha256:5230d9d65f39063a313ed1820df775166227ec5c20a1122968f85653d5efee48", size = 124745, upload-time = "2026-02-09T15:23:34.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/800bdaeabd3eb126aff7e3e22dc45b2826305f61cbfd093284caf8d9ca01/pytest_codspeed-4.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2acecc4126658abebc683b38121adec405a46e18a619d49d6154c6e60c5deb2", size = 347077, upload-time = "2026-02-09T15:23:17.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f1/d69707440829adab86d078d5f1c8c070df116b1624f8eae4ff36933ba612/pytest_codspeed-4.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:619120775e92a3f43fb4ff4c256a251b1554c904d95e2154a382484283f0388a", size = 342234, upload-time = "2026-02-09T15:23:18.407Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/15/ec0ac1f022173b3134c9638f2a35f21fbb3142c75da066d9e49e5a8bb4bd/pytest_codspeed-4.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbeff1eb2f2e36df088658b556fa993e6937bf64ffb07406de4db16fd2b26874", size = 347076, upload-time = "2026-02-09T15:23:19.989Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e8/1fe375794ad02b7835f378a7bcfa8fbac9acadefe600a782a7c4a7064db7/pytest_codspeed-4.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:878aad5e4bb7b401ad8d82f3af5186030cd2bd0d0446782e10dabb9db8827466", size = 342215, upload-time = "2026-02-09T15:23:20.954Z" },
+    { url = "https://files.pythonhosted.org/packages/09/58/50df94e9a78e1c77818a492c90557eeb1309af025120c9a21e6375950c52/pytest_codspeed-4.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527a3a02eaa3e4d4583adc4ba2327eef79628f3e1c682a4b959439551a72588e", size = 347395, upload-time = "2026-02-09T15:23:21.986Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/7dfbd3eefd112a14e6fb65f9ff31dacf2e9c381cb94b27332b81d2b13f8d/pytest_codspeed-4.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9858c2a6e1f391d5696757e7b6e9484749a7376c46f8b4dd9aebf093479a9667", size = 342625, upload-time = "2026-02-09T15:23:23.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/53/7255f6a25bc56ff1745b254b21545dfe0be2268f5b91ce78f7e8a908f0ad/pytest_codspeed-4.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34f2fd8497456eefbd325673f677ea80d93bb1bc08a578c1fa43a09cec3d1879", size = 347325, upload-time = "2026-02-09T15:23:23.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f8/82ae570d8b9ad30f33c9d4002a7a1b2740de0e090540c69a28e4f711ebe2/pytest_codspeed-4.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df6a36a2a9da1406bc50428437f657f0bd8c842ae54bee5fb3ad30e01d50c0f5", size = 342558, upload-time = "2026-02-09T15:23:25.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e1/55cfe9474f91d174c7a4b04d257b5fc6d4d06f3d3680f2da672ee59ccc10/pytest_codspeed-4.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bec30f4fc9c4973143cd80f0d33fa780e9fa3e01e4dbe8cedf229e72f1212c62", size = 347383, upload-time = "2026-02-09T15:23:26.68Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3b/8fd781d959bbe789b3de8ce4c50d5706a684a0df377147dfb27b200c20c1/pytest_codspeed-4.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6584e641cadf27d894ae90b87c50377232a97cbfd76ee0c7ecd0c056fa3f7f4", size = 342481, upload-time = "2026-02-09T15:23:27.686Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0c/368045133c6effa2c665b1634b7b8a9c88b307f877fa31f1f8df47885b51/pytest_codspeed-4.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0d1f6ea594f29b745c634d66d5f5f1caa1c3abd2af82fea49d656038e8fc77", size = 353680, upload-time = "2026-02-09T15:23:28.726Z" },
+    { url = "https://files.pythonhosted.org/packages/59/21/e543abcd72244294e25ae88ec3a9311ade24d6913f8c8f42569d671700bc/pytest_codspeed-4.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2f5bb6d8898bea7db45e3c8b916ee48e36905b929477bb511b79c5a3ccacda4", size = 347888, upload-time = "2026-02-09T15:23:30.443Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/b8a53c20cf5b41042c205bb9d36d37da00418d30fd1a94bf9eb147820720/pytest_codspeed-4.3.0-py3-none-any.whl", hash = "sha256:05baff2a61dc9f3e92b92b9c2ab5fb45d9b802438f5373073f5766a91319ed7a", size = 125224, upload-time = "2026-02-09T15:23:33.774Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `.github/workflows/benchmarks.yml` running CodSpeed on push to main and PRs
- Add `benchmarks/test_bench.py` with 12 pytest-codspeed benchmarks covering load, save, match, and security scrub operations across YAML/TOML formats at 100/1000 interactions

## Test plan
- [x] All 12 benchmarks pass locally with `uv run pytest benchmarks/test_bench.py --codspeed`
- [ ] Verify CodSpeed action runs on PR CI