### PR TITLE
Add documentation site built with Zensical

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - ".github/workflows/docs.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --only-group docs
+      - run: uv run --no-sync zensical build --clean
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v6
+      - uses: actions/deploy-pages@v5
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ rust/target/
 
 # Coverage
 .coverage
+/site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,107 @@
+# Cassetter
+
+Cassetter is a Rust powered HTTP cassette recorder for Python tests. Safe by default.
+
+The first time your test runs, Cassetter records the real HTTP interactions to a **cassette** file. Every run after that, it replays the recorded responses. No network needed. Fast, deterministic tests.
+
+The key features are:
+
+* **Safe by default**: sensitive headers, query parameters, and body fields are filtered at write time. Cassettes never contain secrets.
+* **Fast**: parsing, matching, and serialization run in a Rust core. Loading cassettes is 3 to 6 times faster than VCR.py.
+* **Secure**: cassette YAML is parsed in Rust. There is no way for a cassette file to execute Python code.
+* **Readable cassettes**: JSON bodies are stored as structured YAML, not escaped strings. Diffs stay clean.
+* **Multi protocol**: HTTP, gRPC, WebSockets, and streaming (SSE) responses.
+* **Drop in**: designed as a replacement for VCR.py and pytest-recording, with the same `@pytest.mark.vcr` marker.
+
+## Requirements
+
+Python 3.10+
+
+Cassetter has no required runtime dependencies. It intercepts the HTTP libraries you already have installed.
+
+## Installation
+
+```console
+$ uv add cassetter
+```
+
+Or with pip:
+
+```console
+$ pip install cassetter
+```
+
+## Example
+
+Mark a test with `@pytest.mark.vcr`:
+
+```python
+import httpx
+import pytest
+
+
+@pytest.mark.vcr(record_mode="once")
+async def test_get_users():
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://api.example.com/users")
+    assert response.status_code == 200
+```
+
+Now run it:
+
+```console
+$ pytest
+```
+
+The first run performs the real request and saves the interaction to `tests/cassettes/test_get_users/test_get_users.yaml`.
+
+Run it again. This time the response comes from the cassette. No network. Same result.
+
+That's it.
+
+## What the cassette looks like
+
+Open the file. It is plain YAML, and JSON bodies are stored as structure, not as escaped strings:
+
+```yaml
+version: 1
+interactions:
+  - request:
+      method: GET
+      uri: https://api.example.com/users
+      headers:
+        accept:
+          - '*/*'
+    response:
+      status: 200
+      headers:
+        content-type:
+          - application/json
+      body:
+        type: json
+        content:
+          users:
+            - id: 1
+              name: Alice
+    recorded_at: '2026-02-20T10:30:01Z'
+```
+
+Notice what is **not** there: no `authorization` header, no cookies, no API keys. Cassetter strips them before writing. You will read more about it in [Safe by default](tutorial/security.md).
+
+## Supported libraries
+
+| Library | Protocol |
+|---------|----------|
+| httpx | HTTP |
+| aiohttp | HTTP |
+| requests | HTTP |
+| urllib3 | HTTP |
+| pyreqwest-impersonate | HTTP |
+| grpcio | gRPC |
+| websockets | WebSocket |
+
+Cassetter detects which libraries are installed and intercepts them automatically. You can also select them explicitly, see [Use the context manager](tutorial/context-manager.md).
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,55 @@
+# Migrate from VCR.py
+
+Cassetter is designed as a drop in replacement for VCR.py and pytest-recording. Most projects migrate with minimal changes.
+
+## Your cassettes keep working
+
+Existing VCR cassettes work as is. Cassetter reads both the VCR format and its own format.
+
+When a cassette is re-recorded, it is written in Cassetter's format, with structured JSON bodies instead of escaped strings.
+
+To bulk convert cassettes without re-recording, use the CLI:
+
+```console
+$ cassetter convert tests/cassettes/ toml
+```
+
+See [Cassette formats](tutorial/formats.md) for the details.
+
+## Your markers keep working
+
+Cassetter uses the same `@pytest.mark.vcr` marker, the same `vcr_config` fixture, and the same `--record-mode` command line flag as pytest-recording. In many projects, the migration is:
+
+```console
+$ uv remove vcrpy pytest-recording
+$ uv add cassetter
+$ pytest
+```
+
+## What changed
+
+| pytest-recording / VCR.py | Cassetter | Notes |
+|---|---|---|
+| `vcr` fixture | `cassette` fixture | `vcr` still works as an alias |
+| `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
+| `filter_query_parameters` | `filter_query_parameters` | Same name |
+| `before_record_request` | `before_record_request` | Same name, same behavior |
+| `before_record_response` | `before_record_response` | Same name, same behavior |
+| `decode_compressed_response` | automatic | Responses are always decompressed |
+| `filter_post_data_parameters` | `body_scrub_patterns` | Pattern based instead of parameter name based |
+
+## What is intentionally different
+
+Filtering is **on by default**. VCR.py records `authorization` headers unless you configure `filter_headers` yourself. Cassetter strips the common sensitive headers, query parameters, and body fields without any configuration. If you relied on credentials being in the cassette (for example, asserting on them), you will need to adjust those tests.
+
+## Not supported
+
+Some VCR.py features have no Cassetter equivalent yet:
+
+* `before_playback_response`: modifying responses during playback.
+* `allow_playback_repeats`: replaying the same interaction multiple times.
+* `record_on_exception`: skipping the save when the test raises.
+* Custom matchers via `register_matcher`.
+* `@pytest.mark.block_network` and `--disable-recording`.
+
+If you depend on one of these, open an issue and tell us about your use case.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,40 @@
+# Performance
+
+Cassette parsing, matching, and serialization run in Rust, through a PyO3 extension module. There is no Python level YAML parsing at all.
+
+## Benchmarks
+
+Compared with VCR.py (which uses PyYAML with libyaml), on a cassette with 1000 interactions:
+
+```
+                cassetter    vcrpy       speedup
+load            13.53 ms     58.90 ms    4.4x
+match           0.98 ms      1.29 ms     1.3x
+save            7.58 ms      45.64 ms    6.0x
+```
+
+TOML cassettes load about 2 times faster than YAML and produce about 12% smaller files:
+
+```
+                YAML         TOML
+save            10.59 ms     11.67 ms
+load            18.99 ms     9.79 ms
+size            768.0 KB     675.3 KB
+```
+
+## Why it matters
+
+A single cassette load taking 50 ms sounds harmless. Now multiply it by 500 tests, each loading a cassette in its setup. That is 25 seconds of pure parsing overhead per test run, before a single assertion executes.
+
+At Cassetter's speed the same suite spends about 7 seconds parsing, and switching the large cassettes to TOML brings it further down.
+
+## Reproduce the numbers
+
+The benchmarks live in the repository and run against your machine:
+
+```console
+$ uv run python benchmarks/bench.py
+$ uv run python benchmarks/bench_formats.py
+```
+
+They are also tracked continuously in CI with CodSpeed, so performance regressions show up in pull requests.

--- a/docs/protocols/grpc.md
+++ b/docs/protocols/grpc.md
@@ -1,0 +1,70 @@
+# gRPC
+
+Cassetter records and replays gRPC calls made with `grpc.aio`.
+
+## Install
+
+```console
+$ uv add "cassetter[grpc]"
+```
+
+## Record and replay
+
+Add `"grpc"` to the interceptor list:
+
+```python
+import grpc
+
+from cassetter import use_cassette
+
+with use_cassette("cassette.yaml", intercept=["grpc"]):
+    channel = grpc.aio.insecure_channel("localhost:50051")
+    stub = my_service_pb2_grpc.MyServiceStub(channel)
+    response = await stub.Echo(my_service_pb2.EchoRequest(message="hello"))
+```
+
+All four gRPC call patterns are supported:
+
+* unary-unary
+* server streaming
+* client streaming
+* bidirectional streaming
+
+## The cassette
+
+gRPC interactions are stored in their own section. Bodies are binary protobuf, stored as hex:
+
+```yaml
+grpc_interactions:
+  - request:
+      method: /mypackage.MyService/Echo
+      metadata: {}
+      body:
+        type: binary
+        content: 0a0568656c6c6f
+    response:
+      status_code: 0
+      status_message: OK
+      metadata: {}
+      body:
+        type: binary
+        content: 0a0568656c6c6f
+    json_debug:
+      request:
+        message: hello
+      response:
+        message: hello
+```
+
+The `json_debug` section is optional and purely for humans: when `google.protobuf` is available, Cassetter adds a readable representation of the request and response messages, so you can tell what a cassette contains without decoding protobuf in your head.
+
+Streaming responses use length prefixed binary encoding. Multiple response chunks are stored in a single body field and decoded back into individual messages on replay.
+
+## Security filtering
+
+The same write time filtering as HTTP applies:
+
+* Sensitive **metadata** keys (like `authorization` and `x-api-key`) are stripped from requests and responses.
+* The **`json_debug`** payload is scrubbed with the body scrub patterns, so a field like `password` shows up as `[FILTERED]`.
+
+Binary protobuf bodies are stored as is, they cannot be pattern scrubbed.

--- a/docs/protocols/streaming.md
+++ b/docs/protocols/streaming.md
@@ -1,0 +1,49 @@
+# Streaming and SSE
+
+SSE (Server-Sent Events) responses work out of the box. This is the streaming mechanism used by OpenAI, Anthropic, Groq, and most other LLM APIs, which makes it one of the most common reasons to record cassettes in the first place.
+
+Nothing to configure:
+
+```python
+from cassetter import use_cassette
+
+with use_cassette("cassette.yaml", record_mode="once"):
+    with client.messages.stream(  # your LLM SDK of choice
+        model="claude-sonnet-5",
+        messages=[{"role": "user", "content": "Hello!"}],
+        max_tokens=1024,
+    ) as stream:
+        for text in stream.text_stream:
+            print(text, end="")
+```
+
+## The cassette
+
+The full response body is recorded as readable text:
+
+```yaml
+response:
+  status: 200
+  headers:
+    content-type:
+      - text/event-stream
+  body:
+    type: text
+    content: |+
+      data: {"id":"chatcmpl-abc","choices":[{"delta":{"role":"assistant"}}]}
+
+      data: {"id":"chatcmpl-abc","choices":[{"delta":{"content":"Hello"}}]}
+
+      data: [DONE]
+```
+
+You can read every event, and diffs show exactly which chunk changed.
+
+## How replay works
+
+On replay, the buffered body is returned to the client SDK, which parses the SSE events from it.
+
+Chunk boundaries are not preserved. That is fine for SSE: parsers split events on `\n\n` boundaries regardless of how the bytes were delivered on the wire. Your SDK sees the same events in the same order.
+
+!!! note
+    This matches how VCR.py handles streaming responses, so cassettes recorded for streaming endpoints behave the same way after migrating.

--- a/docs/protocols/websockets.md
+++ b/docs/protocols/websockets.md
@@ -1,0 +1,59 @@
+# WebSockets
+
+Cassetter records and replays WebSocket connections made with the `websockets` library.
+
+## Install
+
+```console
+$ uv add "cassetter[websockets]"
+```
+
+## Record and replay
+
+Add `"websockets"` to the interceptor list:
+
+```python
+import websockets
+
+from cassetter import use_cassette
+
+with use_cassette("cassette.yaml", intercept=["websockets"]):
+    async with websockets.connect("wss://ws.example.com/stream") as ws:
+        await ws.send('{"subscribe": "ticker"}')
+        data = await ws.recv()
+```
+
+## The cassette
+
+Each frame is recorded with its direction, type, and timing offset:
+
+```yaml
+ws_interactions:
+  - uri: wss://ws.example.com/stream
+    headers: {}
+    frames:
+      - direction: send
+        frame_type: text
+        body:
+          type: text
+          content: '{"subscribe": "ticker"}'
+        offset_ms: 0
+      - direction: recv
+        frame_type: text
+        body:
+          type: json
+          content:
+            price: 42.5
+        offset_ms: 120
+```
+
+On replay, `recv()` returns the recorded frames in order, without a real connection. `send()` is a no-op. Both text and binary frames are supported.
+
+## Security filtering
+
+The same write time filtering as HTTP applies:
+
+* Sensitive **handshake headers** (like `authorization` and `cookie`) are stripped.
+* **Text and JSON frame bodies** are scrubbed with the body scrub patterns. An authentication frame like `{"access_token": "..."}` is stored with the token replaced by `[FILTERED]`.
+
+Binary frames are stored as is.

--- a/docs/tutorial/concurrency.md
+++ b/docs/tutorial/concurrency.md
@@ -1,0 +1,60 @@
+# Concurrency
+
+Multiple cassettes can be active at the same time in the same process. Each `use_cassette()` context gets its own isolated cassette through a `contextvars.ContextVar`.
+
+This works out of the box with `asyncio.gather`, `anyio` task groups, and any framework that creates async tasks:
+
+```python
+import asyncio
+
+import httpx
+
+from cassetter import use_cassette
+
+
+async def task_a():
+    with use_cassette("cassettes/a.yaml", record_mode="none"):
+        async with httpx.AsyncClient() as client:
+            return await client.get("https://api.example.com/data")
+
+
+async def task_b():
+    with use_cassette("cassettes/b.yaml", record_mode="none"):
+        async with httpx.AsyncClient() as client:
+            return await client.get("https://api.example.com/data")
+
+
+results = await asyncio.gather(task_a(), task_b())
+```
+
+Each task records to and replays from its own cassette. No cross contamination.
+
+This matters in practice: evaluation frameworks like Pydantic Evals run cases with `max_concurrency > 1`, and each case can have its own cassette.
+
+## Threads
+
+Threads are different. A `contextvars` context does not propagate into a `ThreadPoolExecutor` automatically, so by default a thread sees **no active cassette** and its requests pass through to the real server.
+
+To propagate the cassette into a thread, copy the context explicitly:
+
+```python
+import contextvars
+from concurrent.futures import ThreadPoolExecutor
+
+import httpx
+
+from cassetter import use_cassette
+
+with use_cassette("cassette.yaml", record_mode="none"):
+    ctx = contextvars.copy_context()
+
+    def work():
+        with httpx.Client() as client:
+            return client.get("https://api.example.com/data")
+
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(ctx.run, work)
+        result = future.result()
+```
+
+The key part is `ctx.run(work)`: the thread executes `work` inside the copied context, where the cassette is active.

--- a/docs/tutorial/context-manager.md
+++ b/docs/tutorial/context-manager.md
@@ -1,0 +1,77 @@
+# Use the context manager
+
+If you are not using pytest, or you want explicit control, use `use_cassette()` directly:
+
+```python
+import httpx
+
+from cassetter import use_cassette
+
+with use_cassette("tests/cassettes/my_test.yaml", record_mode="once"):
+    with httpx.Client() as client:
+        response = client.get("https://api.example.com/users")
+```
+
+Everything inside the `with` block is recorded or replayed. When the block exits, the cassette is saved.
+
+The context manager yields the cassette, so you can inspect it:
+
+```python
+with use_cassette("cassette.yaml", record_mode="once") as cassette:
+    ...
+    print(len(cassette.interactions))
+```
+
+!!! note
+    `use_cassette()` defaults to the `once` record mode: record if the cassette doesn't exist, replay if it does. The pytest plugin defaults to `none` instead.
+
+## All the options
+
+```python
+with use_cassette(
+    "cassette.yaml",
+    record_mode="once",
+    match_on=["method", "uri"],
+    ignore_json_paths=["request_id"],
+    filter_headers=["x-custom-secret"],
+    filter_query_parameters=["signature"],
+    body_scrub_patterns=["my_secret_field"],
+    filter_replacement="[FILTERED]",
+    intercept=["httpx", "aiohttp"],
+    max_age="30d",
+    on_expiry="warn",
+    ignore_localhost=True,
+    ignore_hosts=["*.googleapis.com"],
+    before_record_request=my_request_hook,
+    before_record_response=my_response_hook,
+):
+    ...
+```
+
+Each option has its own section in this tutorial. The important thing to remember: **you only need the path**. Everything else has safe defaults.
+
+## Select the intercepted libraries
+
+By default, Cassetter detects which HTTP libraries are installed and intercepts all of them. To limit interception to specific libraries, pass `intercept`:
+
+```python
+with use_cassette("cassette.yaml", intercept=["httpx"]):
+    ...
+```
+
+The available names are `httpx`, `aiohttp`, `requests`, `urllib3`, `pyreqwest`, `grpc`, and `websockets`.
+
+!!! tip
+    gRPC and WebSocket interception are not part of auto detection. Add `"grpc"` or `"websockets"` explicitly when you need them. See [gRPC](../protocols/grpc.md) and [WebSockets](../protocols/websockets.md).
+
+## Nesting
+
+Cassettes can be nested. The inner cassette takes over while its block is active, and the outer one is restored when it exits:
+
+```python
+with use_cassette("outer.yaml"):
+    ...  # recorded to outer.yaml
+    with use_cassette("inner.yaml"):
+        ...  # recorded to inner.yaml
+    ...  # recorded to outer.yaml again
+```

--- a/docs/tutorial/expiry.md
+++ b/docs/tutorial/expiry.md
@@ -1,0 +1,39 @@
+# Cassette expiry
+
+Cassettes rot. The API adds a field, renames another, and your tests keep passing against a response from six months ago.
+
+Set `max_age` to catch that:
+
+```python
+with use_cassette("cassette.yaml", max_age="30d", on_expiry="rerecord"):
+    ...
+```
+
+`max_age` accepts durations like `"24h"`, `"7d"`, `"4w"`. When the cassette is older than that, `on_expiry` decides what happens:
+
+| Action | Behavior |
+|--------|----------|
+| `warn` | Emit a `CassetteExpiredWarning` (the default) |
+| `fail` | Raise `CassetteExpiredError` |
+| `rerecord` | Delete the cassette and record it again |
+
+## With pytest
+
+Configure it for a module through `vcr_config`:
+
+```python
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {"max_age": "30d", "on_expiry": "warn"}
+```
+
+Or per test, through the marker:
+
+```python
+@pytest.mark.vcr(max_age="7d", on_expiry="fail")
+async def test_fresh_data():
+    ...
+```
+
+!!! tip
+    A good setup: `on_expiry="warn"` in CI so nothing breaks unexpectedly, and an occasional local run with `--record-mode=all` to refresh everything.

--- a/docs/tutorial/filtering.md
+++ b/docs/tutorial/filtering.md
@@ -1,0 +1,84 @@
+# Filter and skip requests
+
+Sometimes you don't want a request in the cassette at all. Telemetry calls, authentication providers, requests to your local services. Cassetter gives you three tools for that.
+
+## Ignore localhost
+
+Requests to `localhost` and `127.0.0.1` pass through to the real server. No recording, no replay:
+
+```python
+with use_cassette("cassette.yaml", ignore_localhost=True):
+    ...
+```
+
+This is useful when your test talks to a real local service (say, a database API in a container) and to an external API at the same time. The local traffic stays live, the external traffic goes through the cassette.
+
+## Ignore hosts
+
+Bypass the cassette for specific hosts, with `fnmatch` patterns:
+
+```python
+with use_cassette(
+    "cassette.yaml",
+    ignore_hosts=["*.googleapis.com", "accounts.google.com"],
+):
+    ...
+```
+
+`*` matches any sequence of characters. Matched requests pass through live.
+
+## The `before_record_request` hook
+
+For everything else, there is a hook. It runs before each request is recorded or replayed, and it receives a `RawRequest` you can inspect and modify:
+
+```python
+from cassetter import RawRequest, SkipRecording, use_cassette
+
+
+def my_hook(request: RawRequest) -> RawRequest:
+    if not request.uri.startswith("https://api.mycompany.com"):
+        raise SkipRecording
+    request.headers.pop("x-internal-trace", None)
+    return request
+
+
+with use_cassette("cassette.yaml", before_record_request=my_hook):
+    ...
+```
+
+Two things you can do:
+
+* **Modify the request** before it is recorded: strip headers, rewrite the URI, whatever you need. Return the modified request.
+* **Skip it entirely**: raise `SkipRecording` and the request passes through to the real server, without recording.
+
+## The `before_record_response` hook
+
+The same idea, for responses:
+
+```python
+from cassetter import RawResponse, SkipRecording, use_cassette
+
+
+def my_hook(response: RawResponse) -> RawResponse:
+    if response.status >= 500:
+        raise SkipRecording  # don't record server errors
+    response.headers.pop("x-request-id", None)
+    return response
+
+
+with use_cassette("cassette.yaml", before_record_response=my_hook):
+    ...
+```
+
+Raising `SkipRecording` here skips recording the whole interaction.
+
+Both hooks work with the pytest plugin through `vcr_config`:
+
+```python
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "before_record_request": my_hook,
+        "ignore_hosts": ["*.googleapis.com"],
+    }
+```

--- a/docs/tutorial/formats.md
+++ b/docs/tutorial/formats.md
@@ -1,0 +1,85 @@
+# Cassette formats
+
+Cassettes can be stored as **YAML** (the default) or **TOML**. The format is detected from the file extension: `.yaml` and `.yml` for YAML, `.toml` for TOML.
+
+## YAML
+
+The default, and the most readable. JSON bodies are stored as structured YAML:
+
+```yaml
+version: 1
+interactions:
+  - request:
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+      headers:
+        content-type:
+          - application/json
+      body:
+        type: json
+        content:
+          model: gpt-4o
+          messages:
+            - role: user
+              content: Hello!
+    response:
+      status: 200
+      body:
+        type: json
+        content:
+          id: chatcmpl-abc123
+          choices:
+            - message:
+                role: assistant
+                content: Hi there!
+    recorded_at: '2026-02-20T10:30:01Z'
+```
+
+Compare that to VCR.py, where the same body would be one long escaped string. When the API response changes, your git diff shows exactly which field changed.
+
+## TOML
+
+Use the `.toml` extension to get TOML cassettes:
+
+```python
+with use_cassette("cassette.toml"):
+    ...
+```
+
+TOML loads about 2 times faster than YAML and produces about 12% smaller files. The tradeoff: TOML cannot represent `null` values or heterogeneous arrays, so body content is stored as a JSON string instead of as structure.
+
+!!! tip
+    Use YAML when humans read the cassettes, use TOML when you have thousands of interactions and load time matters.
+
+## Convert between formats
+
+The `cassetter` CLI converts existing cassettes:
+
+```console
+$ cassetter convert cassette.yaml cassette.toml
+```
+
+Convert a whole directory in place, changing extensions:
+
+```console
+$ cassetter convert tests/cassettes/ toml
+```
+
+Or convert into a separate output directory:
+
+```console
+$ cassetter convert tests/cassettes/ output/ --to toml
+```
+
+## Body types
+
+Bodies are stored with an explicit type, so replay is always faithful:
+
+| Type | Content |
+|------|---------|
+| `json` | Structured data, stored as YAML structure |
+| `text` | Plain text, stored as a string |
+| `binary` | Anything else, stored as hex |
+| `none` | Empty body |
+
+Compressed responses (gzip, brotli, zstd) are decompressed before recording, so the cassette always contains readable content.

--- a/docs/tutorial/matching.md
+++ b/docs/tutorial/matching.md
@@ -1,0 +1,47 @@
+# Request matching
+
+When a request is made under an active cassette, Cassetter searches the recorded interactions for one that **matches**. If it finds one, it replays the recorded response. Each interaction is replayed at most once, in order.
+
+By default, requests match on **method** and **URI**. That is predictable and sufficient for most tests.
+
+## Configure the matchers
+
+Pass `match_on` with the fields you want:
+
+```python
+with use_cassette(
+    "cassette.yaml",
+    match_on=["method", "uri", "json_body"],
+):
+    ...
+```
+
+The available matchers:
+
+| Matcher | Matches on |
+|---------|-----------|
+| `method` | HTTP method (`GET`, `POST`, ...) |
+| `uri` | Full URI, including the query string |
+| `headers` | Request headers (recorded headers must be a subset) |
+| `body` | Raw request body |
+| `json_body` | Request body parsed as JSON |
+
+## Ignore volatile JSON fields
+
+APIs love to include request IDs, timestamps, and other values that change on every call. If you match on `json_body`, those fields would break every replay.
+
+Ignore them with `ignore_json_paths`:
+
+```python
+with use_cassette(
+    "cassette.yaml",
+    match_on=["method", "uri", "json_body"],
+    ignore_json_paths=["request_id", "timestamp"],
+):
+    ...
+```
+
+Now two bodies that differ only in `request_id` and `timestamp` are considered equal.
+
+!!! tip
+    Start with the default `["method", "uri"]`. Only add `json_body` when your test makes several requests to the same URI with different payloads and you need to tell them apart.

--- a/docs/tutorial/pytest.md
+++ b/docs/tutorial/pytest.md
@@ -1,0 +1,131 @@
+# Use it with pytest
+
+Cassetter ships with a pytest plugin. It is installed and activated automatically, you don't need to configure anything.
+
+## Mark a test
+
+Add the `@pytest.mark.vcr` marker to any test that makes HTTP requests:
+
+```python
+import httpx
+import pytest
+
+
+@pytest.mark.vcr
+async def test_api_call():
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://api.example.com/users")
+    assert response.status_code == 200
+```
+
+Each marked test gets its own cassette file at:
+
+```
+{test_dir}/cassettes/{test_file_stem}/{test_name}.yaml
+```
+
+For a test `test_api_call` in `tests/test_users.py`, that is `tests/cassettes/test_users/test_api_call.yaml`.
+
+For tests inside a class, the class name is included: `TestUsers.test_api_call.yaml`.
+
+## Record the cassette
+
+By default the plugin runs in the `none` record mode: replay only, never touch the network. To record cassettes for the first time, pass `--record-mode`:
+
+```console
+$ pytest --record-mode=once
+```
+
+After that, run pytest normally and the tests replay from the cassettes.
+
+!!! tip
+    Keeping `none` as the default is intentional. Your test suite will fail loudly if a cassette is missing or stale, instead of silently making real requests in CI.
+
+You can read about all the modes in [Record modes](record-modes.md).
+
+## Access the cassette
+
+If you need to inspect the recorded interactions, request the `cassette` fixture:
+
+```python
+from cassetter import Cassette
+
+
+@pytest.mark.vcr
+async def test_with_cassette(cassette: Cassette):
+    async with httpx.AsyncClient() as client:
+        await client.get("https://api.example.com/users")
+    assert len(cassette.interactions) == 1
+```
+
+The fixture is also available under the name `vcr`, for compatibility with pytest-recording.
+
+## Configure with `vcr_config`
+
+Override the `vcr_config` fixture to set options for a whole module:
+
+```python
+import pytest
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "record_mode": "once",
+        "match_on": ["method", "uri", "json_body"],
+        "filter_headers": ["x-custom-secret"],
+        "ignore_hosts": ["*.googleapis.com"],
+    }
+```
+
+The supported keys are the same options accepted by `use_cassette()`:
+
+| Key | Description |
+|-----|-------------|
+| `record_mode` | Recording behavior, see [Record modes](record-modes.md) |
+| `match_on` | Fields used to match requests |
+| `ignore_json_paths` | JSON paths ignored during matching |
+| `filter_headers` | Headers stripped from cassettes |
+| `filter_query_parameters` | Query params replaced in cassettes |
+| `body_scrub_patterns` | Body field patterns scrubbed from cassettes |
+| `filter_replacement` | Replacement string for filtered values |
+| `cassette_dir` | Cassette directory, relative to the test file |
+| `intercept` | Libraries to intercept |
+| `max_age` | Cassette expiry, e.g. `"30d"` |
+| `on_expiry` | What to do with expired cassettes |
+| `ignore_localhost` | Bypass requests to localhost |
+| `ignore_hosts` | Bypass requests to matching hosts |
+| `before_record_request` | Hook to modify or skip requests |
+| `before_record_response` | Hook to modify or skip responses |
+
+## Configure per test
+
+The marker accepts overrides for a single test:
+
+```python
+@pytest.mark.vcr("custom_name.yaml", record_mode="all")
+async def test_special_case():
+    ...
+```
+
+The first positional argument sets the cassette file name. The keyword arguments `record_mode`, `cassette_dir`, `max_age`, and `on_expiry` override the module configuration.
+
+The command line flag `--record-mode` overrides everything.
+
+## Customize the cassette directory
+
+Override the `vcr_cassette_dir` fixture:
+
+```python
+@pytest.fixture(scope="module")
+def vcr_cassette_dir():
+    return "tests/my_cassettes"
+```
+
+## Find orphaned cassettes
+
+Over time, tests get renamed and deleted, and their cassettes stay behind. Find cassette files that no test uses:
+
+```console
+$ pytest --vcr-check-orphans=tests/cassettes/
+```

--- a/docs/tutorial/record-modes.md
+++ b/docs/tutorial/record-modes.md
@@ -1,0 +1,61 @@
+# Record modes
+
+The record mode controls what happens when a request is made under an active cassette.
+
+| Mode | Behavior |
+|------|----------|
+| `none` | Replay only. Raises `NoMatchError` if no recorded interaction matches. |
+| `once` | Record if the cassette doesn't exist. Replay if it does. |
+| `new_episodes` | Replay existing interactions. Record new ones. |
+| `all` | Record everything, overwriting the cassette. |
+
+## `none`
+
+Use it in CI and for day to day test runs. Nothing touches the network. If a request has no matching interaction in the cassette, the test fails with `NoMatchError`.
+
+```python
+with use_cassette("cassette.yaml", record_mode="none"):
+    ...
+```
+
+## `once`
+
+Use it while developing. The first run records, every run after that replays.
+
+```python
+with use_cassette("cassette.yaml", record_mode="once"):
+    ...
+```
+
+This is the default for `use_cassette()`.
+
+## `new_episodes`
+
+Use it when you add new requests to an existing test. Matched requests replay from the cassette, unmatched requests go to the real server and get appended.
+
+```python
+with use_cassette("cassette.yaml", record_mode="new_episodes"):
+    ...
+```
+
+## `all`
+
+Use it to re-record a cassette from scratch, for example after an API change.
+
+```python
+with use_cassette("cassette.yaml", record_mode="all"):
+    ...
+```
+
+## Set the mode from the command line
+
+With the pytest plugin, `--record-mode` overrides whatever the tests configure:
+
+```console
+$ pytest --record-mode=once
+```
+
+A common workflow:
+
+* Locally, record new cassettes with `pytest --record-mode=once`.
+* In CI, run plain `pytest`. The plugin default is `none`, so CI never makes real requests.

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -1,0 +1,93 @@
+# Safe by default
+
+Here is a story that happens all the time: a developer records a cassette, the `authorization` header goes into the YAML file, the file gets committed, and now there is an API token in the git history. Forever.
+
+Cassetter is designed so this cannot happen. Sensitive data is filtered **at write time**. The secrets never reach the disk, so there is nothing to leak.
+
+## What is filtered
+
+These request and response **headers** are stripped automatically:
+
+`authorization`, `cookie`, `set-cookie`, `x-api-key`, `api-key`, `x-auth-token`, `proxy-authorization`, `www-authenticate`
+
+These **query parameters** are replaced with `[FILTERED]`:
+
+`api_key`, `apikey`, `token`, `access_token`, `client_secret`
+
+These **JSON body fields** are scrubbed, at any nesting level:
+
+`password`, `access_token`, `refresh_token`, `client_secret`
+
+The same rules apply to every protocol:
+
+* HTTP: headers, query parameters, and bodies.
+* gRPC: request and response metadata, and the `json_debug` payload.
+* WebSockets: handshake headers and text or JSON frame bodies.
+
+Binary protobuf bodies are stored as is. They cannot be pattern scrubbed.
+
+## See it in action
+
+Record a request with credentials:
+
+```python
+with use_cassette("cassette.yaml", record_mode="once"):
+    httpx.post(
+        "https://api.example.com/login?api_key=super-secret",
+        headers={"authorization": "Bearer token123"},
+        json={"username": "alice", "password": "hunter2"},
+    )
+```
+
+This is what lands in the cassette:
+
+```yaml
+interactions:
+  - request:
+      method: POST
+      uri: https://api.example.com/login?api_key=[FILTERED]
+      headers:
+        content-type:
+          - application/json
+      body:
+        type: json
+        content:
+          username: alice
+          password: '[FILTERED]'
+```
+
+No `authorization` header. No API key. No password.
+
+## Customize the filters
+
+Add your own headers, patterns, and replacement string:
+
+```python
+with use_cassette(
+    "cassette.yaml",
+    filter_headers=["x-custom-secret"],
+    filter_query_parameters=["signature"],
+    body_scrub_patterns=["my_secret_field"],
+    filter_replacement="***REDACTED***",
+):
+    ...
+```
+
+!!! warning
+    Passing `filter_headers` **replaces** the default list, it does not extend it. If you want the defaults plus your own, get them from `SecurityConfig`:
+
+    ```python
+    from cassetter import SecurityConfig
+
+    filter_headers=[*SecurityConfig().filter_headers, "x-custom-secret"]
+    ```
+
+Body scrub patterns are matched case insensitively against JSON keys, at any depth. A pattern matches if the key contains it, so `token` matches `access_token` and `refresh_token` too.
+
+## YAML safety
+
+There is a second security angle to cassettes: loading them.
+
+VCR.py parses cassettes with an unsafe YAML loader that supports `!!python/object` tags. A malicious cassette file can execute arbitrary Python code when loaded.
+
+Cassetter parses YAML in Rust. The Rust parser has no concept of Python object construction, only data. A cassette file can never run code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ dev = [
     "vcrpy>=8.1.1",
     "pytest-codspeed>=3.2",
 ]
+docs = [
+    "zensical>=0.0.46",
+]
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,9 @@ dev = [
     { name = "vcrpy" },
     { name = "websockets" },
 ]
+docs = [
+    { name = "zensical" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -261,6 +264,7 @@ dev = [
     { name = "vcrpy", specifier = ">=8.1.1" },
     { name = "websockets", specifier = ">=12.0" },
 ]
+docs = [{ name = "zensical", specifier = ">=0.0.46" }]
 
 [[package]]
 name = "certifi"
@@ -440,6 +444,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -630,11 +646,20 @@ wheels = [
 ]
 
 [[package]]
+name = "deepmerge"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -912,6 +937,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1016,6 +1053,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1025,6 +1071,91 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1529,11 +1660,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -2133,6 +2277,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/57/c7bbb71f943e1e0ba5ce460f4930ec836ead7286969e7fd742f7a6c049ab/zensical-0.0.46.tar.gz", hash = "sha256:3ec21f4fb1e78cd7c0d6b07ae336b04770e27ba020dabc457b2790e5d34f1978", size = 3973968, upload-time = "2026-06-21T18:52:40.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/bd/bbc499ee35ac9ec5459dbfec7bb7231556689e97eaa13a5eddbe1f0443b5/zensical-0.0.46-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d91af81ab058c8693dfd75f2f77b4c73bcba4125681d1d276f38624291820bd2", size = 12796482, upload-time = "2026-06-21T18:52:07.369Z" },
+    { url = "https://files.pythonhosted.org/packages/88/1b/7acc273184d59b8e894d15ebe3cf1c5e81b3a822fde1792ea3e33be37a2e/zensical-0.0.46-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9221264a9a87409900a47e29985607b0c9245dacb89077e87c8e16e31edc167", size = 12660030, upload-time = "2026-06-21T18:52:10.186Z" },
+    { url = "https://files.pythonhosted.org/packages/80/df/bd0a68de98a19fc6050c58be11f36d05ea72a213b6a7ff7395d33c793747/zensical-0.0.46-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec43018d5343ca2e1d71aa352eeddd560fef504effd03025840a5a783abefa4f", size = 13057130, upload-time = "2026-06-21T18:52:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/e27635f5787a42245f900e658340698a6654e165d466f9a3b640efced2cd/zensical-0.0.46-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26e98fb8ab7ab50cdd20a73e2c7d4d9aae0b46cf2d8691e6bb22f9c261b8a60a", size = 13022345, upload-time = "2026-06-21T18:52:15.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9d/6ce2ba11c97154870b458a8dae4637ade93b7097912f0102f5ea7fe8cf5b/zensical-0.0.46-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46fe578f26963f8ee89567983e62737b6fadc9197d4742e1020b522e092d7baa", size = 13377445, upload-time = "2026-06-21T18:52:18.538Z" },
+    { url = "https://files.pythonhosted.org/packages/68/06/9930d43cd9d2f899b648d63491007c1b4f9716cf118b0c98e867b933069c/zensical-0.0.46-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aef03fa186a5589148e10b62610500989c6b075a2c08e1554233adbf91b2a3dc", size = 13086749, upload-time = "2026-06-21T18:52:21.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ed/2342cf860fbb02314938b0d1f1b02344935801b04d185ff3151ef1812898/zensical-0.0.46-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bc7446cdf97a8dea390f20ed2bd6b030cddc1bd36a8ce113ea3efef6fa61c573", size = 13231120, upload-time = "2026-06-21T18:52:24.171Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b0/d2ece02f63cd767fcf10fd7608dc8e0a995f87dc5261209b1dbc296fd57b/zensical-0.0.46-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:bbee37801f1ed500f158dc0992c569282950f780ae353c37fe6969f99983d701", size = 13295035, upload-time = "2026-06-21T18:52:26.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/cb0048a612e63e615399fc507472a557d1c5b7c2f74065c5bf11998fd597/zensical-0.0.46-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:9487c147c9cceb50c04d0ad70b024821a6eab1629dafd70ab6d1e86ec841e623", size = 13437191, upload-time = "2026-06-21T18:52:29.69Z" },
+    { url = "https://files.pythonhosted.org/packages/91/16/515f81db8055b109a510063be481e60a657c4fad1a883680b2ee4aa9a424/zensical-0.0.46-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f42a4683c762f026878d19ede4bcf7bfbb84dbecb5ad923949abb77806ed88a5", size = 13369382, upload-time = "2026-06-21T18:52:32.521Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5c/da54ee65b642eb7d88dd4a3db35845d0765915638e05d5d434a10b42f1c3/zensical-0.0.46-cp310-abi3-win32.whl", hash = "sha256:85f018f2a7ee76a83915c87ddb12b58cf343fd6154081d33ac95b6751b011dd7", size = 12354298, upload-time = "2026-06-21T18:52:34.976Z" },
+    { url = "https://files.pythonhosted.org/packages/73/26/fc7ef081acbdada8436825221cb728ee84a81d4d78a7bb79aa58bd150d31/zensical-0.0.46-cp310-abi3-win_amd64.whl", hash = "sha256:1543a693a160de60e86ca589592401b584670e7e12c5ae30e3c2ba76786f7ec3", size = 12599687, upload-time = "2026-06-21T18:52:37.913Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,84 @@
+[project]
+site_name = "Cassetter"
+site_description = "Rust powered HTTP cassette recorder for Python tests. Safe by default."
+site_author = "Marcelo Trylesinski"
+site_url = "https://kludex.github.io/cassetter/"
+repo_url = "https://github.com/Kludex/cassetter"
+repo_name = "Kludex/cassetter"
+copyright = """
+Copyright &copy; 2026 Marcelo Trylesinski
+"""
+
+nav = [
+    { "Cassetter" = "index.md" },
+    { "Tutorial" = [
+        { "Use it with pytest" = "tutorial/pytest.md" },
+        { "Use the context manager" = "tutorial/context-manager.md" },
+        { "Record modes" = "tutorial/record-modes.md" },
+        { "Request matching" = "tutorial/matching.md" },
+        { "Safe by default" = "tutorial/security.md" },
+        { "Filter and skip requests" = "tutorial/filtering.md" },
+        { "Cassette formats" = "tutorial/formats.md" },
+        { "Cassette expiry" = "tutorial/expiry.md" },
+        { "Concurrency" = "tutorial/concurrency.md" },
+    ] },
+    { "Protocols" = [
+        { "gRPC" = "protocols/grpc.md" },
+        { "WebSockets" = "protocols/websockets.md" },
+        { "Streaming and SSE" = "protocols/streaming.md" },
+    ] },
+    { "Migrate from VCR.py" = "migration.md" },
+    { "Performance" = "performance.md" },
+]
+
+[project.theme]
+features = [
+    "content.code.annotate",
+    "content.code.copy",
+    "content.tabs.link",
+    "content.tooltips",
+    "navigation.footer",
+    "navigation.indexes",
+    "navigation.instant",
+    "navigation.instant.prefetch",
+    "navigation.path",
+    "navigation.sections",
+    "navigation.top",
+    "navigation.tracking",
+    "search.highlight",
+    "toc.follow",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/Kludex/cassetter"
+
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.superfences]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true


### PR DESCRIPTION
Adds a full documentation site for cassetter using [Zensical](https://zensical.org), plus CI to build and deploy it.

- `zensical.toml` with explicit navigation, light/dark palette, and repository integration
- `docs/`: landing page, tutorial (pytest plugin, context manager, record modes, matching, security filtering, request filtering/hooks, formats, expiry, concurrency), protocol guides (gRPC, WebSockets, streaming/SSE), VCR.py migration guide, and performance page
- `.github/workflows/docs.yml`: builds the site on PRs touching docs, deploys to GitHub Pages on push to main via `actions/deploy-pages` (needs GitHub Pages set to "GitHub Actions" in repo settings)
- `zensical` added as a `docs` dependency group; docs CI uses `uv sync --only-group docs` so it never compiles the Rust extension

Content is based on the README and SPECIFICATION, but only documents behavior that actually exists (e.g. the unsupported `vcr_max_age`/`vcr_on_expiry` pytest ini options from the README are not documented; expiry is documented via `vcr_config` and marker kwargs instead).

Site builds clean locally with `uv run zensical build --clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)