### PR TITLE
Support in-place cassette conversion with secret scrubbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # cargo test links against libpython (the extension-module feature is
+      # only enabled by maturin when building the wheel)
+      - run: sudo apt-get update && sudo apt-get install -y libpython3-dev
       - run: cargo test --manifest-path rust/Cargo.toml
 
   test:

--- a/README.md
+++ b/README.md
@@ -489,9 +489,14 @@ cassetter convert cassette.yaml cassette.toml
 # Convert all cassettes in a directory (in-place, changing extension)
 cassetter convert tests/cassettes/ toml
 
+# Rewrite in-place keeping the same format (VCR -> cassetter migration)
+cassetter convert tests/cassettes/ yaml --force
+
 # Convert to a separate output directory
 cassetter convert tests/cassettes/ output/ --to toml
 ```
+
+Conversion applies the default security filtering (headers, query params, body fields), so secrets recorded by VCR.py are removed on the way through. Pass `--no-scrub` to skip it.
 
 ### pytest plugin
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -8,13 +8,19 @@ Existing VCR cassettes work as is. Cassetter reads both the VCR format and its o
 
 When a cassette is re-recorded, it is written in Cassetter's format, with structured JSON bodies instead of escaped strings.
 
-To bulk convert cassettes without re-recording, use the CLI:
+To bulk convert cassettes without re-recording, use the CLI. In place, keeping YAML:
+
+```console
+$ cassetter convert tests/cassettes/ yaml --force
+```
+
+Or changing the format to TOML:
 
 ```console
 $ cassetter convert tests/cassettes/ toml
 ```
 
-See [Cassette formats](tutorial/formats.md) for the details.
+Conversion applies the default security filtering, so any secrets VCR.py recorded (it keeps `authorization` headers by default) are removed on the way through. Pass `--no-scrub` to skip that. See [Cassette formats](tutorial/formats.md) for the details.
 
 ## Your markers keep working
 

--- a/docs/tutorial/formats.md
+++ b/docs/tutorial/formats.md
@@ -71,6 +71,24 @@ Or convert into a separate output directory:
 $ cassetter convert tests/cassettes/ output/ --to toml
 ```
 
+Rewrite cassettes in place, keeping the same format. This requires `--force` because it overwrites the source files:
+
+```console
+$ cassetter convert tests/cassettes/ yaml --force
+```
+
+This is the command you want when migrating a VCR.py cassette corpus: every file is re-read (Cassetter understands the VCR format) and re-written in Cassetter's format. Writes go through a temp file, so an interrupted run never leaves a truncated cassette.
+
+## Conversion scrubs by default
+
+`cassetter convert` applies the default security filtering to every interaction it writes: sensitive headers, query parameters, and body fields are removed or replaced, exactly as at record time. Cassettes recorded by VCR.py usually contain real `authorization` headers, so this matters.
+
+If you need a byte-faithful conversion instead, opt out:
+
+```console
+$ cassetter convert cassette.yaml cassette.toml --no-scrub
+```
+
 ## Body types
 
 Bodies are stored with an explicit type, so replay is always faithful:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +84,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 name = "cassetter"
 version = "0.0.0"
 dependencies = [
+ "base64",
  "brotli",
  "chrono",
  "flate2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ name = "_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.28" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -20,3 +20,4 @@ unicode-normalization = "0.1"
 pythonize = "0.28"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
+base64 = "0.22"

--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -12,6 +12,7 @@ use super::Cassette;
 /// Also accepts VCR-format cassettes on read (but never writes that format).
 #[derive(Serialize, Deserialize)]
 pub struct RawCassette {
+    #[serde(default = "default_version")]
     pub version: u32,
     pub interactions: Vec<RawInteraction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -36,6 +37,10 @@ pub struct RawRequest {
     pub headers: HashMap<String, Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_body")]
     pub body: RawBody,
+    /// Structured JSON body used by pydantic-ai style VCR serializers in
+    /// place of `body`. Read-only compatibility - never written back out.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parsed_body: Option<serde_yaml::Value>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -46,6 +51,9 @@ pub struct RawResponse {
     pub headers: HashMap<String, Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_body")]
     pub body: RawBody,
+    /// See `RawRequest::parsed_body`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parsed_body: Option<serde_yaml::Value>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -54,6 +62,10 @@ pub struct RawBody {
     pub body_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<serde_yaml::Value>,
+}
+
+fn default_version() -> u32 {
+    1
 }
 
 fn default_none_type() -> String {
@@ -208,12 +220,18 @@ pub fn from_raw(raw: RawCassette) -> pyo3::PyResult<Cassette> {
                 method: ri.request.method,
                 uri: ri.request.uri,
                 headers: ri.request.headers,
-                body: body_from_raw(ri.request.body),
+                body: match ri.request.parsed_body {
+                    Some(v) => Body::json(yaml_to_json(v)),
+                    None => body_from_raw(ri.request.body),
+                },
             };
             let response = HttpResponse {
                 status: ri.response.status,
                 headers: ri.response.headers,
-                body: body_from_raw(ri.response.body),
+                body: match ri.response.parsed_body {
+                    Some(v) => Body::json(yaml_to_json(v)),
+                    None => body_from_raw(ri.response.body),
+                },
             };
             HttpInteraction {
                 request,
@@ -261,11 +279,13 @@ pub fn to_raw(cassette: &Cassette) -> RawCassette {
                 uri: i.request.uri.clone(),
                 headers: i.request.headers.clone(),
                 body: body_to_raw(&i.request.body),
+                parsed_body: None,
             },
             response: RawResponse {
                 status: i.response.status,
                 headers: i.response.headers.clone(),
                 body: body_to_raw(&i.response.body),
+                parsed_body: None,
             },
             recorded_at: if i.recorded_at.is_empty() {
                 None

--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -33,7 +33,7 @@ pub struct RawInteraction {
 pub struct RawRequest {
     pub method: String,
     pub uri: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_headers")]
     pub headers: HashMap<String, Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_body")]
     pub body: RawBody,
@@ -47,7 +47,7 @@ pub struct RawRequest {
 pub struct RawResponse {
     #[serde(deserialize_with = "deserialize_status")]
     pub status: u16,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_headers")]
     pub headers: HashMap<String, Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_body")]
     pub body: RawBody,
@@ -95,6 +95,48 @@ where
     }
 }
 
+/// Rewrite PyYAML's `!!binary` block scalars into the local tag `!b64`.
+///
+/// serde_yaml silently drops `!!binary` tags, yielding the base64 text as a
+/// plain string, which loses the fact that the value was binary. Local
+/// single-`!` tags survive as `Value::Tagged`, so the tag is rewritten before
+/// parsing. Only the block form PyYAML emits (`... !!binary |` at end of
+/// line) is rewritten, which cannot appear inside a quoted scalar.
+pub fn tag_binary_scalars(content: &str) -> String {
+    if !content.contains("!!binary") {
+        return content.to_string();
+    }
+    let lines: Vec<String> = content
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_end();
+            if trimmed.ends_with("!!binary |") || trimmed.ends_with("!!binary |-") {
+                if let Some(pos) = line.rfind("!!binary ") {
+                    let mut out = String::with_capacity(line.len());
+                    out.push_str(&line[..pos]);
+                    out.push_str("!b64 ");
+                    out.push_str(&line[pos + "!!binary ".len()..]);
+                    return out;
+                }
+            }
+            line.to_string()
+        })
+        .collect();
+    lines.join("\n")
+}
+
+/// Decode a `!b64`-tagged scalar produced by `tag_binary_scalars`.
+fn decode_b64_tagged(tagged: &serde_yaml::value::TaggedValue) -> Option<Vec<u8>> {
+    use base64::Engine;
+    if tagged.tag != "!b64" {
+        return None;
+    }
+    let text: String = tagged.value.as_str()?.split_whitespace().collect();
+    base64::engine::general_purpose::STANDARD.decode(text).ok()
+}
+
+const KNOWN_BODY_TYPES: &[&str] = &["json", "text", "binary", "none"];
+
 /// Deserialize body from either cassetter format `{type: ..., content: ...}` or VCR format.
 ///
 /// VCR body formats:
@@ -102,6 +144,8 @@ where
 /// - `""` (empty string) -> none
 /// - `"raw string"` -> detect JSON or use text
 /// - `{string: "..."}` -> detect JSON or use text
+/// - `{string: !!binary ...}` -> binary
+/// - any other mapping -> structured JSON body (aiohttp-recorded shape)
 fn deserialize_body<'de, D>(deserializer: D) -> Result<RawBody, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -110,25 +154,84 @@ where
     match &value {
         serde_yaml::Value::Null => Ok(RawBody::default()),
         serde_yaml::Value::String(s) => Ok(vcr_string_to_raw_body(s)),
+        serde_yaml::Value::Tagged(t) => Ok(match decode_b64_tagged(t) {
+            Some(bytes) => binary_raw_body(&bytes),
+            None => RawBody::default(),
+        }),
         serde_yaml::Value::Mapping(map) => {
             let type_key = serde_yaml::Value::String("type".to_string());
+            let content_key = serde_yaml::Value::String("content".to_string());
             let string_key = serde_yaml::Value::String("string".to_string());
-            if map.contains_key(&type_key) {
-                // Cassetter format - deserialize normally
+            let is_cassetter_body = map
+                .get(&type_key)
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| KNOWN_BODY_TYPES.contains(&t))
+                && map.iter().all(|(k, _)| *k == type_key || *k == content_key);
+            if is_cassetter_body {
                 serde_yaml::from_value(value).map_err(serde::de::Error::custom)
             } else if let Some(string_val) = map.get(&string_key) {
                 // VCR format: {string: "..."}
                 match string_val {
                     serde_yaml::Value::Null => Ok(RawBody::default()),
                     serde_yaml::Value::String(s) => Ok(vcr_string_to_raw_body(s)),
+                    serde_yaml::Value::Tagged(t) => Ok(match decode_b64_tagged(t) {
+                        Some(bytes) => binary_raw_body(&bytes),
+                        None => RawBody::default(),
+                    }),
                     _ => Ok(RawBody::default()),
                 }
             } else {
-                // Unknown mapping, treat as none
-                Ok(RawBody::default())
+                // Bare mapping: a structured JSON body recorded directly
+                // (e.g. aiohttp-recorded request bodies)
+                Ok(RawBody {
+                    body_type: "json".to_string(),
+                    content: Some(value),
+                })
             }
         }
         _ => Ok(RawBody::default()),
+    }
+}
+
+fn binary_raw_body(bytes: &[u8]) -> RawBody {
+    RawBody {
+        body_type: "binary".to_string(),
+        content: Some(serde_yaml::Value::String(hex_encode(bytes))),
+    }
+}
+
+/// Deserialize a header map, decoding `!!binary` header values to strings.
+fn deserialize_headers<'de, D>(deserializer: D) -> Result<HashMap<String, Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_yaml::Value::deserialize(deserializer)?;
+    let serde_yaml::Value::Mapping(map) = value else {
+        return Ok(HashMap::new());
+    };
+    let mut headers = HashMap::new();
+    for (key, values) in map {
+        let Some(name) = key.as_str().map(str::to_string) else {
+            continue;
+        };
+        let decoded: Vec<String> = match values {
+            serde_yaml::Value::Sequence(seq) => seq.iter().filter_map(header_value_to_string).collect(),
+            other => header_value_to_string(&other).into_iter().collect(),
+        };
+        headers.insert(name, decoded);
+    }
+    Ok(headers)
+}
+
+fn header_value_to_string(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        serde_yaml::Value::Tagged(t) => {
+            decode_b64_tagged(t).map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        }
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
     }
 }
 
@@ -530,4 +633,105 @@ fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
             u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| format!("hex decode error: {e}"))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_binary_body_and_headers_from_vcr() {
+        // "ABCD" base64 in body, "application/json" base64 in header
+        let yaml = "\
+version: 1
+interactions:
+- request:
+    method: GET
+    uri: https://example.com
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    body:
+      string: !!binary |
+        QUJDRA==
+";
+        let content = tag_binary_scalars(yaml);
+        let raw: RawCassette = serde_yaml::from_str(&content).unwrap();
+        let cassette = from_raw(raw).unwrap();
+        let response = &cassette.interactions[0].response;
+        assert_eq!(response.headers["content-type"], vec!["application/json"]);
+        match &response.body.inner {
+            BodyContent::Binary(b) => assert_eq!(b, b"ABCD"),
+            other => panic!("expected binary body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bare_mapping_body_is_json() {
+        let yaml = "\
+interactions:
+- request:
+    method: POST
+    uri: https://example.com
+    headers: {}
+    body:
+      model: llama
+      stream: false
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: {}
+";
+        let raw: RawCassette = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.version, 1);
+        let cassette = from_raw(raw).unwrap();
+        match &cassette.interactions[0].request.body.inner {
+            BodyContent::Json(v) => {
+                assert_eq!(v["model"], "llama");
+                assert_eq!(v["stream"], false);
+            }
+            other => panic!("expected json body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_json_body_with_type_key_not_mistaken_for_cassetter_format() {
+        let yaml = "\
+interactions:
+- request:
+    method: POST
+    uri: https://example.com
+    headers: {}
+    body:
+      type: function
+      name: get_weather
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: {}
+";
+        let raw: RawCassette = serde_yaml::from_str(yaml).unwrap();
+        let cassette = from_raw(raw).unwrap();
+        match &cassette.interactions[0].request.body.inner {
+            BodyContent::Json(v) => {
+                assert_eq!(v["type"], "function");
+                assert_eq!(v["name"], "get_weather");
+            }
+            other => panic!("expected json body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_tag_binary_scalars_leaves_content_untouched() {
+        let yaml = "body:\n  string: |\n    text mentioning !!binary | in prose\n";
+        assert_eq!(tag_binary_scalars(yaml), yaml.trim_end());
+    }
 }

--- a/rust/src/cassette/mod.rs
+++ b/rust/src/cassette/mod.rs
@@ -159,6 +159,7 @@ impl Cassette {
             return Ok(format_toml::from_toml(raw));
         }
 
+        let content = format::tag_binary_scalars(&content);
         let raw: format::RawCassette = serde_yaml::from_str(&content).map_err(|e| {
             pyo3::exceptions::PyValueError::new_err(format!("YAML parse error: {e}"))
         })?;

--- a/src/cassetter/cli.py
+++ b/src/cassetter/cli.py
@@ -63,7 +63,11 @@ def convert(args: argparse.Namespace) -> None:
         print(f"error: {dst} already exists (use --force to overwrite)", file=sys.stderr)
         sys.exit(1)
 
-    n = convert_file(src, dst, scrub=scrub)
+    try:
+        n = convert_file(src, dst, scrub=scrub)
+    except (ValueError, OSError) as exc:
+        print(f"error: {src}: {exc}", file=sys.stderr)
+        sys.exit(1)
     print(f"Converted {n} interaction(s): {src} -> {dst}")
 
 
@@ -92,6 +96,7 @@ def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | No
         sys.exit(1)
 
     converted = 0
+    failed = 0
     for src_file in sources:
         rel = src_file.relative_to(src_dir)
         if target_ext is not None:
@@ -108,10 +113,18 @@ def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | No
             continue
 
         dst_file.parent.mkdir(parents=True, exist_ok=True)
-        n = convert_file(src_file, dst_file, scrub=scrub)
+        try:
+            n = convert_file(src_file, dst_file, scrub=scrub)
+        except (ValueError, OSError) as exc:
+            print(f"error: {src_file}: {exc}", file=sys.stderr)
+            failed += 1
+            continue
         print(f"  {rel} -> {dst_file.relative_to(out_dir)} ({n} interaction(s))")
         converted += 1
 
+    if failed:
+        print(f"Converted {converted} file(s), failed {failed}")
+        sys.exit(1)
     print(f"Converted {converted} file(s)")
 
 

--- a/src/cassetter/cli.py
+++ b/src/cassetter/cli.py
@@ -4,21 +4,47 @@ import argparse
 import sys
 from pathlib import Path
 
-from cassetter._core import Cassette
+from cassetter._core import (
+    Cassette,
+    SecurityConfig,
+    scrub_grpc_interaction,
+    scrub_interaction,
+    scrub_ws_interaction,
+)
 
 EXTENSIONS = {".yaml", ".yml", ".toml"}
 
 
-def convert_file(src: Path, dst: Path) -> int:
+def scrub_cassette(cassette: Cassette, config: SecurityConfig) -> Cassette:
+    """Return a copy of the cassette with security filtering applied to every interaction."""
+    scrubbed = Cassette()
+    for interaction in cassette.interactions:
+        scrubbed.add_interaction(scrub_interaction(interaction, config))
+    for grpc_interaction in cassette.grpc_interactions:
+        scrubbed.add_grpc_interaction(scrub_grpc_interaction(grpc_interaction, config))
+    for ws_interaction in cassette.ws_interactions:
+        scrubbed.add_ws_interaction(scrub_ws_interaction(ws_interaction, config))
+    return scrubbed
+
+
+def convert_file(src: Path, dst: Path, *, scrub: bool = True) -> int:
     """Convert a single cassette file. Returns the number of interactions."""
     cassette = Cassette.load(str(src))
-    cassette.save(str(dst))
+    if scrub:
+        cassette = scrub_cassette(cassette, SecurityConfig())
+    # Write via a temp file so an interrupted conversion never leaves a
+    # truncated cassette. The temp name keeps the real extension because
+    # save() detects the format from it.
+    tmp = dst.with_suffix(f".tmp{dst.suffix}")
+    cassette.save(str(tmp))
+    tmp.replace(dst)
     return len(cassette)
 
 
 def convert(args: argparse.Namespace) -> None:
     src = Path(args.input)
     dst = Path(args.output)
+    scrub = not args.no_scrub
 
     if not src.exists():
         print(f"error: {src} not found", file=sys.stderr)
@@ -26,18 +52,22 @@ def convert(args: argparse.Namespace) -> None:
 
     if src.is_dir():
         to_ext = f".{args.to}" if args.to else None
-        convert_directory(src, dst, force=args.force, to_ext=to_ext)
+        convert_directory(src, dst, force=args.force, to_ext=to_ext, scrub=scrub)
         return
 
-    if dst.exists() and not args.force:
+    if src == dst and not args.force:
+        print(f"error: converting {src} in place requires --force", file=sys.stderr)
+        sys.exit(1)
+
+    if src != dst and dst.exists() and not args.force:
         print(f"error: {dst} already exists (use --force to overwrite)", file=sys.stderr)
         sys.exit(1)
 
-    n = convert_file(src, dst)
+    n = convert_file(src, dst, scrub=scrub)
     print(f"Converted {n} interaction(s): {src} -> {dst}")
 
 
-def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | None) -> None:
+def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | None, scrub: bool = True) -> None:
     """Convert all cassette files in a directory tree.
 
     *dst* is either an existing/new directory, or a bare extension like ``toml``
@@ -56,7 +86,7 @@ def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | No
     else:
         out_dir = dst
 
-    sources = sorted(p for p in src_dir.rglob("*") if p.suffix in EXTENSIONS)
+    sources = sorted(p for p in src_dir.rglob("*") if p.suffix in EXTENSIONS and ".tmp" not in p.suffixes)
     if not sources:
         print(f"error: no cassette files found in {src_dir}", file=sys.stderr)
         sys.exit(1)
@@ -69,15 +99,16 @@ def convert_directory(src_dir: Path, dst: Path, *, force: bool, to_ext: str | No
         else:
             dst_file = out_dir / rel
 
-        if src_file == dst_file:
+        if src_file == dst_file and not force:
+            print(f"skip: {src_file} (in-place rewrite requires --force)", file=sys.stderr)
             continue
 
-        if dst_file.exists() and not force:
+        if src_file != dst_file and dst_file.exists() and not force:
             print(f"skip: {dst_file} already exists", file=sys.stderr)
             continue
 
         dst_file.parent.mkdir(parents=True, exist_ok=True)
-        n = convert_file(src_file, dst_file)
+        n = convert_file(src_file, dst_file, scrub=scrub)
         print(f"  {rel} -> {dst_file.relative_to(out_dir)} ({n} interaction(s))")
         converted += 1
 
@@ -93,6 +124,11 @@ def main(argv: list[str] | None = None) -> None:
     convert_parser.add_argument("output", help="Destination file, directory, or target format (e.g. 'toml')")
     convert_parser.add_argument("--force", "-f", action="store_true", help="Overwrite existing files")
     convert_parser.add_argument("--to", choices=["yaml", "toml"], help="Target format when output is a directory")
+    convert_parser.add_argument(
+        "--no-scrub",
+        action="store_true",
+        help="Skip security filtering (headers, query params, body fields) during conversion",
+    )
 
     args = parser.parse_args(argv)
 

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -615,3 +615,79 @@ def test_vcr_format_playback(tmp_path: object) -> None:
     response = cassette.play("GET", "https://api.example.com/users", {}, None)
     assert response.status == 200
     assert response.body.content == {"users": []}
+
+
+def test_vcr_format_parsed_body(tmp_path: object) -> None:
+    """pydantic-ai style serializer: structured `parsed_body` instead of `body`."""
+    path = os.path.join(str(tmp_path), "parsed.yaml")
+    _write_vcr_cassette(
+        path,
+        [
+            {
+                "request": {
+                    "method": "POST",
+                    "uri": "https://api.example.com/chat",
+                    "headers": {"content-type": ["application/json"]},
+                    "parsed_body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+                },
+                "response": {
+                    "status": {"code": 200, "message": "OK"},
+                    "headers": {"content-type": ["application/json"]},
+                    "parsed_body": {"id": "abc", "choices": [{"message": {"content": "hello"}}]},
+                },
+            }
+        ],
+    )
+    c = RustCassette.load(path)
+    i = c.interactions[0]
+    assert i.request.body.body_type == "json"
+    assert i.request.body.content["model"] == "gpt-4o"
+    assert i.response.body.body_type == "json"
+    assert i.response.body.content["choices"][0]["message"]["content"] == "hello"
+
+
+def test_vcr_format_missing_version(tmp_path: object) -> None:
+    """Cassettes written without a top-level version key load with version 1."""
+    path = os.path.join(str(tmp_path), "no_version.yaml")
+    data = {
+        "interactions": [
+            {
+                "request": {"method": "GET", "uri": "https://example.com", "headers": {}},
+                "response": {"status": {"code": 200, "message": "OK"}, "headers": {}},
+            }
+        ]
+    }
+    with open(path, "w") as f:
+        yaml.dump(data, f)
+
+    c = RustCassette.load(path)
+    assert c.version == 1
+    assert len(c) == 1
+
+
+def test_parsed_body_saves_as_cassetter_format(tmp_path: object) -> None:
+    """parsed_body cassettes are rewritten in cassetter's own body format on save."""
+    path = os.path.join(str(tmp_path), "parsed.yaml")
+    _write_vcr_cassette(
+        path,
+        [
+            {
+                "request": {
+                    "method": "GET",
+                    "uri": "https://example.com",
+                    "headers": {},
+                    "parsed_body": {"q": 1},
+                },
+                "response": {"status": {"code": 200, "message": "OK"}, "headers": {}},
+            }
+        ],
+    )
+    c = RustCassette.load(path)
+    out = os.path.join(str(tmp_path), "out.yaml")
+    c.save(out)
+
+    with open(out) as f:
+        raw = yaml.safe_load(f)
+    request = raw["interactions"][0]["request"]
+    assert "parsed_body" not in request
+    assert request["body"] == {"type": "json", "content": {"q": 1}}

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -691,3 +691,53 @@ def test_parsed_body_saves_as_cassetter_format(tmp_path: object) -> None:
     request = raw["interactions"][0]["request"]
     assert "parsed_body" not in request
     assert request["body"] == {"type": "json", "content": {"q": 1}}
+
+
+def test_vcr_format_binary_body_and_headers(tmp_path: object) -> None:
+    """PyYAML !!binary scalars (bodies and header values) decode to real bytes."""
+    path = os.path.join(str(tmp_path), "binary.yaml")
+    data = {
+        "interactions": [
+            {
+                "request": {"method": "GET", "uri": "https://example.com/stream", "headers": {}},
+                "response": {
+                    "status": {"code": 200, "message": "OK"},
+                    "headers": {"content-type": [b"application/vnd.amazon.eventstream"]},
+                    "body": {"string": b"\x00\x01\xffbinary-payload"},
+                },
+            }
+        ]
+    }
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f)
+
+    c = RustCassette.load(path)
+    response = c.interactions[0].response
+    assert response.headers["content-type"] == ["application/vnd.amazon.eventstream"]
+    assert response.body.body_type == "binary"
+    assert response.body.content == b"\x00\x01\xffbinary-payload"
+
+
+def test_vcr_format_bare_mapping_request_body(tmp_path: object) -> None:
+    """A structured dict directly under request.body (aiohttp recordings) loads as JSON."""
+    path = os.path.join(str(tmp_path), "mapping.yaml")
+    data = {
+        "interactions": [
+            {
+                "request": {
+                    "method": "POST",
+                    "uri": "https://example.com/chat",
+                    "headers": {},
+                    "body": {"model": "llama", "stream": False},
+                },
+                "response": {"status": {"code": 200, "message": "OK"}, "headers": {}},
+            }
+        ]
+    }
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f)
+
+    c = RustCassette.load(path)
+    body = c.interactions[0].request.body
+    assert body.body_type == "json"
+    assert body.content == {"model": "llama", "stream": False}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,117 @@ def test_convert_directory_skips_existing(tmp_path: Path) -> None:
     main(["convert", str(src_dir), "toml"])
 
 
+@pytest.fixture()
+def secret_cassette(tmp_path: Path) -> str:
+    """A VCR-era cassette carrying secrets in headers, query params, and bodies."""
+    path = str(tmp_path / "secrets.yaml")
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest(
+                "POST",
+                "https://example.com/login?api_key=hunter2&page=1",
+                {"authorization": ["Bearer tok123"], "accept": ["application/json"]},
+                Body("json", {"password": "hunter2", "user": "alice"}),
+            ),
+            HttpResponse(
+                200,
+                {"set-cookie": ["session=abc"]},
+                Body("json", {"access_token": "tok456", "ok": True}),
+            ),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(path)
+    return path
+
+
+def test_convert_scrubs_by_default(secret_cassette: str, tmp_path: Path) -> None:
+    dst = str(tmp_path / "clean.yaml")
+    main(["convert", secret_cassette, dst])
+
+    loaded = Cassette.load(dst)
+    request = loaded.interactions[0].request
+    response = loaded.interactions[0].response
+    assert "authorization" not in request.headers
+    assert request.headers["accept"] == ["application/json"]
+    assert "hunter2" not in request.uri
+    assert "page=1" in request.uri
+    assert request.body.content["password"] == "[FILTERED]"
+    assert request.body.content["user"] == "alice"
+    assert "set-cookie" not in response.headers
+    assert response.body.content["access_token"] == "[FILTERED]"
+    assert response.body.content["ok"] is True
+
+
+def test_convert_no_scrub_preserves_data(secret_cassette: str, tmp_path: Path) -> None:
+    dst = str(tmp_path / "raw.yaml")
+    main(["convert", secret_cassette, dst, "--no-scrub"])
+
+    loaded = Cassette.load(dst)
+    request = loaded.interactions[0].request
+    assert request.headers["authorization"] == ["Bearer tok123"]
+    assert "api_key=hunter2" in request.uri
+    assert request.body.content["password"] == "hunter2"
+
+
+def test_convert_in_place_requires_force(yaml_cassette: str) -> None:
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", yaml_cassette, yaml_cassette])
+
+
+def test_convert_in_place_with_force(secret_cassette: str) -> None:
+    main(["convert", secret_cassette, secret_cassette, "--force"])
+
+    loaded = Cassette.load(secret_cassette)
+    assert len(loaded) == 1
+    assert "authorization" not in loaded.interactions[0].request.headers
+    # No temp file left behind
+    assert not Path(secret_cassette).with_suffix(".tmp.yaml").exists()
+
+
+def test_convert_directory_in_place_requires_force(tmp_path: Path) -> None:
+    src_dir = tmp_path / "cassettes"
+    src_dir.mkdir()
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "https://example.com", {"authorization": ["Bearer x"]}),
+            HttpResponse(200),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(str(src_dir / "test.yaml"))
+
+    # Without --force, same-path files are skipped and left untouched
+    main(["convert", str(src_dir), "yaml"])
+    loaded = Cassette.load(str(src_dir / "test.yaml"))
+    assert loaded.interactions[0].request.headers["authorization"] == ["Bearer x"]
+
+
+def test_convert_directory_in_place_with_force(tmp_path: Path) -> None:
+    src_dir = tmp_path / "cassettes"
+    (src_dir / "nested").mkdir(parents=True)
+    for name in ("a.yaml", "nested/b.yml"):
+        c = Cassette()
+        c.add_interaction(
+            HttpInteraction(
+                HttpRequest("GET", f"https://example.com/{name}", {"authorization": ["Bearer x"]}),
+                HttpResponse(200),
+                "2026-01-01T00:00:00Z",
+            )
+        )
+        c.save(str(src_dir / name))
+
+    main(["convert", str(src_dir), "yaml", "--force"])
+
+    loaded = Cassette.load(str(src_dir / "a.yaml"))
+    assert "authorization" not in loaded.interactions[0].request.headers
+    # .yml files are rewritten to the target .yaml extension
+    assert (src_dir / "nested" / "b.yaml").exists()
+    assert not list(src_dir.rglob("*.tmp.*"))
+
+
 def test_convert_no_command() -> None:
     with pytest.raises(SystemExit, match="1"):
         main([])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,6 +239,36 @@ def test_convert_directory_in_place_with_force(tmp_path: Path) -> None:
     assert not list(src_dir.rglob("*.tmp.*"))
 
 
+def test_convert_unreadable_file_errors_cleanly(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("interactions:\n- not_a_request: {}\n")
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", str(bad), str(tmp_path / "out.toml")])
+
+
+def test_convert_directory_continues_after_bad_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    src_dir = tmp_path / "cassettes"
+    src_dir.mkdir()
+    (src_dir / "bad.yaml").write_text("interactions:\n- not_a_request: {}\n")
+    c = Cassette()
+    c.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "https://example.com"),
+            HttpResponse(200),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(str(src_dir / "good.yaml"))
+
+    with pytest.raises(SystemExit, match="1"):
+        main(["convert", str(src_dir), "toml"])
+
+    captured = capsys.readouterr()
+    assert "bad.yaml" in captured.err
+    assert "Converted 1 file(s), failed 1" in captured.out
+    assert (src_dir / "good.toml").exists()
+
+
 def test_convert_no_command() -> None:
     with pytest.raises(SystemExit, match="1"):
         main([])


### PR DESCRIPTION
Extends `cassetter convert` into a real VCR-migration tool, validated end to end against the pydantic-ai test suite (1,076 cassettes, 8,383 tests).

## CLI
- **In-place conversion**: same-path (and same-extension directory) rewrites now work, gated on `--force`. Writes go through a temp file with the correct extension + atomic rename, so an interrupted run never leaves a truncated cassette.
- **Scrub by default**: conversion runs every HTTP/gRPC/WS interaction through the default `SecurityConfig` (VCR.py records `authorization` headers by default, so migrated corpora usually contain secrets). `--no-scrub` opts out.
- **Per-file error handling**: a directory conversion reports unconvertible files and continues instead of dying with a traceback (exit 1 with a `Converted X, failed Y` summary).

## VCR-compat loader fixes (found by converting the real corpus)
- `parsed_body` structured JSON bodies (pydantic-ai's custom serializer) were silently loaded as empty bodies.
- Missing top-level `version` now defaults to 1.
- `!!binary` scalars: serde_yaml silently drops the tag, so binary bodies/headers were mangled to base64 text. The loader now rewrites the tag to a preserved local tag before parsing and decodes to real bytes - Bedrock `application/vnd.amazon.eventstream` bodies round-trip byte-exact (CRC-validated on replay).
- Bare-mapping bodies (aiohttp recordings) load as structured JSON instead of being dropped.
- A JSON body containing a `type` key is no longer misparsed as a cassetter-format body.

## Build
- pyo3's `extension-module` feature is now injected only by maturin (as intended); hardcoding it in Cargo.toml broke any `cargo test` that links PyO3 symbols. CI installs `libpython3-dev` for the rust-test job.

## Validation on pydantic-ai
1. Baseline with vcrpy: 7877 passed / 0 failed / 503 skipped / 3 xfailed.
2. `cassetter convert tests/... yaml --force`: all 1,076 VCR cassettes converted in ~19s; the 62 `*.xai.yaml` protobuf cassettes correctly refused and untouched.
3. Field-by-field integrity: every interaction equal to `scrub(original)`; 124 binary bodies byte-exact vs PyYAML ground truth; zero data loss.
4. Full suite replayed offline from the converted cassettes (their serializer reading cassetter format): **7877 / 0 / 503 / 3 - exact parity, chunk for chunk**.

The first conversion attempt failed 18 tests (Bedrock checksums, HuggingFace body loss, direct-YAML readers) - those failures drove the loader fixes above; the direct-YAML-reader class was test/format coupling on the pydantic-ai side, needing a small normalize helper during migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)