### PR TITLE
Expose vcrpy-compatible request introspection on `Cassette`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -41,6 +41,7 @@ $ pytest
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
 | `before_record_request` | `before_record_request` | Same name, same behavior |
 | `before_record_response` | `before_record_response` | Same name, same behavior |
+| `cassette.requests`, `play_count`, `play_counts`, `all_played` | Same names | vcrpy-style introspection on the cassette object |
 | `decode_compressed_response` | automatic | Responses are always decompressed |
 | `filter_post_data_parameters` | `body_scrub_patterns` | Pattern based instead of parameter name based |
 

--- a/docs/tutorial/pytest.md
+++ b/docs/tutorial/pytest.md
@@ -60,6 +60,16 @@ async def test_with_cassette(cassette: Cassette):
 
 The fixture is also available under the name `vcr`, for compatibility with pytest-recording.
 
+The cassette exposes vcrpy's introspection surface, so wire-contract assertions port over unchanged: `cassette.requests` returns the recorded requests with `.method`, `.uri`, `.headers`, `.body`, `.path`, `.host`, and `.query` attributes, and `cassette.play_count`, `cassette.play_counts`, and `cassette.all_played` report replay progress.
+
+```python
+@pytest.mark.vcr
+async def test_sends_tool_definitions(cassette: Cassette):
+    ...
+    request_body = json.loads(cassette.requests[0].body)
+    assert request_body["tools"][0]["name"] == "get_weather"
+```
+
 ## Configure with `vcr_config`
 
 Override the `vcr_config` fixture to set options for a whole module:

--- a/src/cassetter/__init__.py
+++ b/src/cassetter/__init__.py
@@ -26,6 +26,7 @@ from cassetter.cassette import (
     SkipRecording,
 )
 from cassetter.context import use_cassette
+from cassetter.introspection import RecordedRequest
 from cassetter.recording import RecordMode
 
 __all__ = [
@@ -45,6 +46,7 @@ __all__ = [
     "MatchConfig",
     "NoMatchError",
     "RawRequest",
+    "RecordedRequest",
     "RawResponse",
     "RecordMode",
     "SkipRecording",

--- a/src/cassetter/cassette.py
+++ b/src/cassetter/cassette.py
@@ -4,6 +4,7 @@ import fnmatch
 import os
 import re
 import warnings
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -30,6 +31,7 @@ from cassetter._core import (
     scrub_interaction,
     scrub_ws_interaction,
 )
+from cassetter.introspection import RecordedRequest, play_counter, recorded_request
 from cassetter.recording import RecordMode
 
 
@@ -155,6 +157,32 @@ class Cassette:
         if self._inner is None:
             return []
         return self._inner.interactions
+
+    @property
+    def requests(self) -> list[RecordedRequest]:
+        """Recorded requests with vcrpy-compatible attributes."""
+        return [recorded_request(i) for i in self.interactions]
+
+    @property
+    def played_indices(self) -> list[bool]:
+        if self._inner is None:
+            return []
+        return self._inner.played_indices
+
+    @property
+    def play_count(self) -> int:
+        """Number of interactions that have been replayed."""
+        return sum(self.played_indices)
+
+    @property
+    def play_counts(self) -> Counter[int]:
+        """Replay count per interaction index, vcrpy style."""
+        return play_counter(self.played_indices)
+
+    @property
+    def all_played(self) -> bool:
+        """Whether every recorded interaction has been replayed."""
+        return all(self.played_indices)
 
     @property
     def grpc_interactions(self) -> list[GrpcInteraction]:

--- a/src/cassetter/introspection.py
+++ b/src/cassetter/introspection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from typing import cast
+from urllib.parse import parse_qsl, urlparse
+
+from cassetter._core import Body, HttpInteraction
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    """A recorded request, exposing vcrpy's `Request` attribute surface.
+
+    `body` is the wire form of the recorded body: a JSON string for `json`
+    bodies, the text for `text` bodies, bytes for `binary` bodies, and None
+    for empty bodies.
+    """
+
+    method: str
+    uri: str
+    headers: dict[str, list[str]]
+    body: str | bytes | None
+
+    @property
+    def scheme(self) -> str:
+        return urlparse(self.uri).scheme
+
+    @property
+    def host(self) -> str | None:
+        return urlparse(self.uri).hostname
+
+    @property
+    def port(self) -> int | None:
+        parsed = urlparse(self.uri)
+        if parsed.port is not None:
+            return parsed.port
+        return _DEFAULT_PORTS.get(parsed.scheme)
+
+    @property
+    def path(self) -> str:
+        return urlparse(self.uri).path
+
+    @property
+    def query(self) -> list[tuple[str, str]]:
+        return sorted(parse_qsl(urlparse(self.uri).query))
+
+
+def recorded_request(interaction: HttpInteraction) -> RecordedRequest:
+    request = interaction.request
+    return RecordedRequest(
+        method=request.method,
+        uri=request.uri,
+        headers=request.headers,
+        body=_wire_body(request.body),
+    )
+
+
+def play_counter(played_indices: list[bool]) -> Counter[int]:
+    return Counter({index: 1 for index, played in enumerate(played_indices) if played})
+
+
+def _wire_body(body: Body) -> str | bytes | None:
+    if body.body_type == "json":
+        return json.dumps(body.content)
+    if body.body_type == "text":
+        return cast(str, body.content)
+    if body.body_type == "binary":
+        return cast(bytes, body.content)
+    return None

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+
+from cassetter import RecordedRequest
+from cassetter._core import Body, Cassette as RustCassette, HttpInteraction, HttpRequest, HttpResponse
+from cassetter.cassette import Cassette
+from cassetter.recording import RecordMode
+
+
+def _make_cassette(tmp_path: object) -> Cassette:
+    path = os.path.join(str(tmp_path), "introspection.yaml")
+    inner = RustCassette()
+    inner.add_interaction(
+        HttpInteraction(
+            HttpRequest(
+                "POST",
+                "https://api.example.com/v1/items?b=2&a=1",
+                {"content-type": ["application/json"]},
+                Body("json", {"name": "widget", "tags": ["a", "b"]}),
+            ),
+            HttpResponse(200, {}, Body("json", {"ok": True})),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    inner.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "http://api.example.com:8080/v2/status", {}, Body("text", "ping")),
+            HttpResponse(200, {}, Body("text", "pong")),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    inner.save(path)
+    cassette = Cassette(path, record_mode=RecordMode.NONE)
+    cassette.load()
+    return cassette
+
+
+def test_requests_exposes_vcr_attributes(tmp_path: object) -> None:
+    cassette = _make_cassette(tmp_path)
+    requests = cassette.requests
+
+    assert len(requests) == 2
+    first = requests[0]
+    assert isinstance(first, RecordedRequest)
+    assert first.method == "POST"
+    assert first.uri == "https://api.example.com/v1/items?b=2&a=1"
+    assert first.headers == {"content-type": ["application/json"]}
+    assert json.loads(first.body) == {"name": "widget", "tags": ["a", "b"]}
+    assert first.scheme == "https"
+    assert first.host == "api.example.com"
+    assert first.port == 443
+    assert first.path == "/v1/items"
+    assert first.query == [("a", "1"), ("b", "2")]
+
+    second = requests[1]
+    assert second.body == "ping"
+    assert second.port == 8080
+    assert second.query == []
+
+
+def test_request_body_wire_forms(tmp_path: object) -> None:
+    path = os.path.join(str(tmp_path), "bodies.yaml")
+    inner = RustCassette()
+    for body in (Body("binary", b"\x00\x01"), Body("none")):
+        inner.add_interaction(
+            HttpInteraction(
+                HttpRequest("POST", "https://example.com", {}, body),
+                HttpResponse(200),
+                "2026-01-01T00:00:00Z",
+            )
+        )
+    inner.save(path)
+    cassette = Cassette(path, record_mode=RecordMode.NONE)
+    cassette.load()
+
+    assert cassette.requests[0].body == b"\x00\x01"
+    assert cassette.requests[1].body is None
+
+
+def test_play_count_lifecycle(tmp_path: object) -> None:
+    cassette = _make_cassette(tmp_path)
+
+    assert cassette.play_count == 0
+    assert cassette.play_counts == Counter()
+    assert not cassette.all_played
+
+    cassette.play("POST", "https://api.example.com/v1/items?b=2&a=1", {}, None)
+    assert cassette.play_count == 1
+    assert cassette.play_counts == Counter({0: 1})
+    assert not cassette.all_played
+
+    cassette.play("GET", "http://api.example.com:8080/v2/status", {}, None)
+    assert cassette.play_count == 2
+    assert cassette.play_counts == Counter({0: 1, 1: 1})
+    assert cassette.all_played
+
+
+def test_introspection_before_load() -> None:
+    cassette = Cassette("/tmp/never-loaded.yaml", record_mode=RecordMode.NONE)
+    assert cassette.requests == []
+    assert cassette.play_count == 0
+    assert cassette.play_counts == Counter()
+    # vcrpy semantics: an empty cassette counts as fully played
+    assert cassette.all_played


### PR DESCRIPTION
Adds vcrpy's cassette introspection surface, unblocking the wire-contract test pattern every serious vcrpy suite relies on:

- `Cassette.requests` - recorded requests as `RecordedRequest` objects with vcrpy's attribute names: `method`, `uri`, `headers`, `body` (wire form: JSON string / text / bytes / None), plus derived `scheme`, `host`, `port` (with scheme defaults, vcrpy-style), `path`, and sorted `query` pairs.
- `Cassette.play_count`, `play_counts` (a `Counter`, vcrpy-style), `all_played` (empty cassette counts as fully played, matching vcrpy), and a public `played_indices`.
- `RecordedRequest` is exported from the package root; conversion lives in a new `cassetter/introspection.py` module.

Semantics were captured from vcrpy directly (attribute shapes, `Counter` type, port defaults, empty-cassette `all_played`) rather than assumed.

## Validation
Beyond unit tests (444 passing): the 11 pydantic-ai test functions (25 test instances) that had to be excluded from the engine benchmark because they assert on `vcr.requests[...].body` now pass unmodified under cassetter as the replay engine - the 5-module subset went from 530 passing with deselects to **555 passing with none**.

Docs updated (pytest tutorial + migration table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)