### PR TITLE
Address review feedback on binary extraction and play counting

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -49,6 +49,10 @@ $ pytest
 
 Filtering is **on by default**. VCR.py records `authorization` headers unless you configure `filter_headers` yourself. Cassetter strips the common sensitive headers, query parameters, and body fields without any configuration. If you relied on credentials being in the cassette (for example, asserting on them), you will need to adjust those tests.
 
+## Known limitation
+
+A raw JSON request body whose keys are exactly `type` and `content`, with `type` equal to `json`, `text`, `binary`, or `none`, is indistinguishable from Cassetter's own body envelope and is read as the envelope. If an API you record uses that exact payload shape, re-record the cassette with Cassetter (which stores the payload inside the envelope) instead of converting it.
+
 ## Not supported
 
 Some VCR.py features have no Cassetter equivalent yet:

--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -159,14 +159,25 @@ pub fn extract_binary_scalars(content: &str) -> (String, Vec<Vec<u8>>) {
                 let node_indent = line_indent(line);
                 let mut b64 = String::new();
                 let mut j = i + 1;
+                // Blank lines are legal inside block scalars and contribute
+                // nothing to base64; only consume them when more block
+                // content follows, so trailing blanks stay with the parent.
+                let mut pending_blanks = 0usize;
                 while j < lines.len() {
                     let content_line = lines[j];
-                    if content_line.trim().is_empty() || line_indent(content_line) <= node_indent {
+                    if content_line.trim().is_empty() {
+                        pending_blanks += 1;
+                        j += 1;
+                        continue;
+                    }
+                    if line_indent(content_line) <= node_indent {
                         break;
                     }
+                    pending_blanks = 0;
                     b64.push_str(content_line.trim());
                     j += 1;
                 }
+                j -= pending_blanks;
                 if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&b64) {
                     out.push(format!("{}{}", &line[..pos], binary_sentinel(binaries.len())));
                     binaries.push(bytes);
@@ -277,6 +288,13 @@ where
                 let value = access.next_value::<Value>()?;
                 map.insert(key, value);
             }
+            // A mapping shaped exactly like cassetter's envelope is treated as
+            // the envelope. This is ambiguous with a bare JSON payload whose
+            // keys are exactly {type, content} with a known type value, but no
+            // cassette-level discriminator exists (VCR files also carry a
+            // top-level version), and preferring the payload interpretation
+            // would corrupt every cassetter-format body instead of this one
+            // rare shape. Documented in the migration guide.
             let is_cassetter_body = map
                 .get("type")
                 .and_then(|v| v.as_str())
@@ -947,6 +965,33 @@ interactions:
                 assert_eq!(v["name"], "get_weather");
             }
             other => panic!("expected json body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_binary_block_with_blank_lines() {
+        // Blank lines are legal inside block scalars; "ABCD" split around one.
+        let yaml = "\
+interactions:
+- request:
+    method: GET
+    uri: https://example.com
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: {}
+    body:
+      string: !!binary |
+        QUJD
+
+        RA==
+";
+        let cassette = load_yaml(yaml);
+        match &cassette.interactions[0].response.body.inner {
+            BodyContent::Binary(b) => assert_eq!(b, b"ABCD"),
+            other => panic!("expected binary body, got {other:?}"),
         }
     }
 

--- a/src/cassetter/cassette.py
+++ b/src/cassetter/cassette.py
@@ -31,7 +31,7 @@ from cassetter._core import (
     scrub_interaction,
     scrub_ws_interaction,
 )
-from cassetter.introspection import RecordedRequest, play_counter, recorded_request
+from cassetter.introspection import RecordedRequest, recorded_request
 from cassetter.recording import RecordMode
 
 
@@ -121,6 +121,7 @@ class Cassette:
         self._inner: _RustCassette | None = None
         self._dirty = False
         self._once_replay_only = False
+        self._play_counter: Counter[int] = Counter()
 
     @property
     def path(self) -> str:
@@ -172,13 +173,13 @@ class Cassette:
 
     @property
     def play_count(self) -> int:
-        """Number of interactions that have been replayed."""
-        return sum(self.played_indices)
+        """Total number of replays, counting repeats (vcrpy semantics)."""
+        return sum(self._play_counter.values())
 
     @property
     def play_counts(self) -> Counter[int]:
-        """Replay count per interaction index, vcrpy style."""
-        return play_counter(self.played_indices)
+        """Replay count per interaction index, counting repeats (vcrpy semantics)."""
+        return Counter(self._play_counter)
 
     @property
     def all_played(self) -> bool:
@@ -209,6 +210,7 @@ class Cassette:
 
         self._inner = _RustCassette.load(self._path)
         self._once_replay_only = True
+        self._play_counter = Counter()
         self._check_expiry()
 
     def _check_expiry(self) -> None:
@@ -293,6 +295,7 @@ class Cassette:
 
         idx, interaction = result
         self._inner.mark_played(idx)
+        self._play_counter[idx] += 1
         return interaction.response
 
     def record(

--- a/src/cassetter/introspection.py
+++ b/src/cassetter/introspection.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from collections import Counter
 from dataclasses import dataclass
 from typing import cast
 from urllib.parse import parse_qsl, urlparse
@@ -57,10 +56,6 @@ def recorded_request(interaction: HttpInteraction) -> RecordedRequest:
         headers=request.headers,
         body=_wire_body(request.body),
     )
-
-
-def play_counter(played_indices: list[bool]) -> Counter[int]:
-    return Counter({index: 1 for index, played in enumerate(played_indices) if played})
 
 
 def _wire_body(body: Body) -> str | bytes | None:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -105,3 +105,26 @@ def test_introspection_before_load() -> None:
     assert cassette.play_counts == Counter()
     # vcrpy semantics: an empty cassette counts as fully played
     assert cassette.all_played
+
+
+def test_play_counts_track_repeats(tmp_path: object) -> None:
+    """Replaying the same interaction twice (matcher fallback) counts both plays."""
+    path = os.path.join(str(tmp_path), "repeats.yaml")
+    inner = RustCassette()
+    inner.add_interaction(
+        HttpInteraction(
+            HttpRequest("GET", "https://example.com/one", {}, Body("none")),
+            HttpResponse(200, {}, Body("json", {"n": 1})),
+            "2026-01-01T00:00:00Z",
+        )
+    )
+    inner.save(path)
+    cassette = Cassette(path, record_mode=RecordMode.NONE)
+    cassette.load()
+
+    cassette.play("GET", "https://example.com/one", {}, None)
+    cassette.play("GET", "https://example.com/one", {}, None)
+
+    assert cassette.play_count == 2
+    assert cassette.play_counts == Counter({0: 2})
+    assert cassette.all_played


### PR DESCRIPTION
Addresses the three Codex review findings left on #35, #36, and #37. Stacked on #38.

1. **#37 - `play_counts` capped at 1** (fixed): repeat replays are real - `find_match` falls back to already-played interactions - but counts were derived from boolean `played_indices`. The wrapper now tracks a true per-index `Counter`, so `play_count`/`play_counts` follow vcrpy's counting semantics (repeats included); `all_played` remains distinct-based, matching vcrpy.
2. **#36 - blank lines inside `!!binary` blocks** (fixed): `extract_binary_scalars` treated any blank line as end-of-scalar. Blank lines are legal in block scalars and contribute nothing to base64; they are now consumed when followed by more block content, with trailing blanks left to the parent node.
3. **#35 - envelope/payload ambiguity** (documented as a known limitation): a bare JSON payload whose keys are exactly `{type, content}` with a known type value is genuinely indistinguishable from cassetter's body envelope, and no cassette-level discriminator exists (VCR files also carry a top-level `version`). Preferring the payload reading would corrupt every cassetter-format body to protect one rare shape, so the envelope keeps priority - now documented in the code and in the migration guide with the workaround (re-record rather than convert).

New regression tests for 1 and 2 (450 Python + 29 Rust tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)