### PR TITLE
Share body decoding and `before_record_request` handling across interceptors

### DIFF
--- a/src/cassetter/intercept/_aiohttp.py
+++ b/src/cassetter/intercept/_aiohttp.py
@@ -14,7 +14,8 @@ from yarl import URL
 
 from cassetter._core import HttpResponse as _HttpResponse
 from cassetter._state import get_current_cassette
-from cassetter.cassette import NoMatchError, RawRequest, SkipRecording
+from cassetter.cassette import NoMatchError
+from cassetter.intercept._shared import apply_before_record_request, body_to_bytes
 
 
 class AiohttpInterceptor:
@@ -46,13 +47,10 @@ class AiohttpInterceptor:
 
             norm_method = method.upper()
 
-            hook = cassette.before_record_request
-            if hook is not None:
-                try:
-                    raw = hook(RawRequest(norm_method, uri, headers, body))
-                except SkipRecording:
-                    return await original_request(session, method, str_or_url, **kwargs)
-                norm_method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
+            raw = apply_before_record_request(cassette.before_record_request, norm_method, uri, headers, body)
+            if raw is None:
+                return await original_request(session, method, str_or_url, **kwargs)
+            norm_method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
 
             try:
                 response = cassette.play(norm_method, uri, headers, body)
@@ -134,15 +132,7 @@ def extract_response_headers(headers: CIMultiDictProxy[str]) -> dict[str, list[s
 
 def build_aiohttp_response(method: str, uri: str, response: _HttpResponse) -> aiohttp.ClientResponse:
 
-    body = response.body
-    if body.body_type == "json":
-        content = json.dumps(body.content).encode()
-    elif body.body_type == "text":
-        content = body.content.encode() if isinstance(body.content, str) else b""
-    elif body.body_type == "binary":
-        content = body.content if isinstance(body.content, bytes) else b""
-    else:
-        content = b""
+    content = body_to_bytes(response.body)
 
     headers_multi: CIMultiDict[str] = CIMultiDict()
     for key, values in response.headers.items():

--- a/src/cassetter/intercept/_httpx_impl.py
+++ b/src/cassetter/intercept/_httpx_impl.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 from cassetter._core import HttpResponse as _HttpResponse
 from cassetter._state import get_current_cassette
-from cassetter.cassette import NoMatchError, RawRequest, SkipRecording
+from cassetter.cassette import NoMatchError
 from cassetter.intercept._base import InterceptorProtocol
+from cassetter.intercept._shared import apply_before_record_request, body_to_bytes
 
 AsyncPassthrough = Callable[[Any], Awaitable[Any]]
 SyncPassthrough = Callable[[Any], Any]
@@ -30,13 +30,10 @@ async def async_intercept(mod: Any, request: Any, passthrough: AsyncPassthrough)
     except mod.RequestNotRead:
         body = await request.aread()
 
-    hook = cassette.before_record_request
-    if hook is not None:
-        try:
-            raw = hook(RawRequest(method, uri, headers, body))
-        except SkipRecording:
-            return await passthrough(request)
-        method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
+    raw = apply_before_record_request(cassette.before_record_request, method, uri, headers, body)
+    if raw is None:
+        return await passthrough(request)
+    method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
 
     try:
         response = cassette.play(method, uri, headers, body)
@@ -81,13 +78,10 @@ def sync_intercept(mod: Any, request: Any, passthrough: SyncPassthrough) -> Any:
     except mod.RequestNotRead:
         body = request.read()
 
-    hook = cassette.before_record_request
-    if hook is not None:
-        try:
-            raw = hook(RawRequest(method, uri, headers, body))
-        except SkipRecording:
-            return passthrough(request)
-        method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
+    raw = apply_before_record_request(cassette.before_record_request, method, uri, headers, body)
+    if raw is None:
+        return passthrough(request)
+    method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
 
     try:
         response = cassette.play(method, uri, headers, body)
@@ -137,15 +131,7 @@ def build_response(mod: Any, response: _HttpResponse, request: Any = None) -> An
         for v in values:
             headers_list.append((key, v))
 
-    body = response.body
-    if body.body_type == "json":
-        content = json.dumps(body.content).encode()
-    elif body.body_type == "text":
-        content = body.content.encode() if isinstance(body.content, str) else b""
-    elif body.body_type == "binary":
-        content = body.content if isinstance(body.content, bytes) else b""
-    else:
-        content = b""
+    content = body_to_bytes(response.body)
 
     return mod.Response(
         status_code=response.status,

--- a/src/cassetter/intercept/_pyreqwest.py
+++ b/src/cassetter/intercept/_pyreqwest.py
@@ -9,7 +9,8 @@ import pyreqwest_impersonate as pri
 
 from cassetter._core import HttpResponse as _HttpResponse
 from cassetter._state import get_current_cassette
-from cassetter.cassette import NoMatchError, RawRequest, SkipRecording
+from cassetter.cassette import NoMatchError
+from cassetter.intercept._shared import apply_before_record_request, body_to_bytes
 
 METHODS_WITH_BODY = frozenset({"post", "put", "patch"})
 ALL_METHODS = ("get", "head", "options", "delete", "post", "put", "patch", "request")
@@ -110,13 +111,10 @@ def intercept(
         json_payload=kwargs.get("json"),
     )
 
-    hook = cassette.before_record_request
-    if hook is not None:
-        try:
-            raw = hook(RawRequest(method, url, norm_headers, body))
-        except SkipRecording:
-            return original(client, *original_args, **kwargs)
-        method, url, norm_headers, body = raw.method, raw.uri, raw.headers, raw.body
+    raw = apply_before_record_request(cassette.before_record_request, method, url, norm_headers, body)
+    if raw is None:
+        return original(client, *original_args, **kwargs)
+    method, url, norm_headers, body = raw.method, raw.uri, raw.headers, raw.body
 
     try:
         response = cassette.play(method, url, norm_headers, body)
@@ -170,15 +168,7 @@ def extract_body(
 
 
 def build_replay_response(url: str, response: _HttpResponse) -> ReplayResponse:
-    body = response.body
-    if body.body_type == "json":
-        content = json.dumps(body.content).encode()
-    elif body.body_type == "text":
-        content = body.content.encode() if isinstance(body.content, str) else b""
-    elif body.body_type == "binary":
-        content = body.content if isinstance(body.content, bytes) else b""
-    else:
-        content = b""
+    content = body_to_bytes(response.body)
 
     flat_headers: dict[str, str] = {}
     for key, values in response.headers.items():

--- a/src/cassetter/intercept/_requests.py
+++ b/src/cassetter/intercept/_requests.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -8,7 +7,8 @@ import requests
 
 from cassetter._core import HttpResponse as _HttpResponse
 from cassetter._state import get_current_cassette
-from cassetter.cassette import NoMatchError, RawRequest, SkipRecording
+from cassetter.cassette import NoMatchError
+from cassetter.intercept._shared import apply_before_record_request, body_to_bytes
 
 
 class RequestsInterceptor:
@@ -37,13 +37,10 @@ class RequestsInterceptor:
             raw_body = request.body
             body = raw_body if isinstance(raw_body, bytes) else (raw_body.encode() if raw_body else None)
 
-            hook = cassette.before_record_request
-            if hook is not None:
-                try:
-                    raw = hook(RawRequest(method, uri, headers, body))
-                except SkipRecording:
-                    return original_send(session, request, **kwargs)
-                method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
+            raw = apply_before_record_request(cassette.before_record_request, method, uri, headers, body)
+            if raw is None:
+                return original_send(session, request, **kwargs)
+            method, uri, headers, body = raw.method, raw.uri, raw.headers, raw.body
 
             try:
                 response = cassette.play(method, uri, headers, body)
@@ -94,15 +91,7 @@ def extract_headers_skip_encoding(headers: Any) -> dict[str, list[str]]:
 
 def build_requests_response(request: requests.PreparedRequest, response: _HttpResponse) -> requests.Response:
 
-    body = response.body
-    if body.body_type == "json":
-        content = json.dumps(body.content).encode()
-    elif body.body_type == "text":
-        content = body.content.encode() if isinstance(body.content, str) else b""
-    elif body.body_type == "binary":
-        content = body.content if isinstance(body.content, bytes) else b""
-    else:
-        content = b""
+    content = body_to_bytes(response.body)
 
     resp = requests.Response()
     resp.status_code = response.status

--- a/src/cassetter/intercept/_shared.py
+++ b/src/cassetter/intercept/_shared.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+
+from cassetter._core import Body
+from cassetter.cassette import BeforeRecordRequest, RawRequest, SkipRecording
+
+
+def apply_before_record_request(
+    hook: BeforeRecordRequest | None,
+    method: str,
+    uri: str,
+    headers: dict[str, list[str]],
+    body: bytes | None,
+) -> RawRequest | None:
+    """Run the before_record_request hook.
+
+    Returns the (possibly modified) request, or None if the hook raised
+    `SkipRecording` and the caller should pass the request through live.
+    """
+    request = RawRequest(method, uri, headers, body)
+    if hook is None:
+        return request
+    try:
+        return hook(request)
+    except SkipRecording:
+        return None
+
+
+def body_to_bytes(body: Body) -> bytes:
+    """Serialize a recorded body to the wire bytes of a replayed response.
+
+    JSON bodies are re-serialized with the stdlib `json` module so the output
+    matches what was originally recorded (separators and non-ASCII escaping),
+    rather than a compact form.
+    """
+    if body.body_type == "json":
+        return json.dumps(body.content).encode()
+    if body.body_type == "text":
+        return body.content.encode() if isinstance(body.content, str) else b""
+    if body.body_type == "binary":
+        return body.content if isinstance(body.content, bytes) else b""
+    return b""

--- a/src/cassetter/intercept/_urllib3.py
+++ b/src/cassetter/intercept/_urllib3.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -11,7 +10,8 @@ import urllib3.response
 
 from cassetter._core import HttpResponse as _HttpResponse
 from cassetter._state import get_current_cassette
-from cassetter.cassette import NoMatchError, RawRequest, SkipRecording
+from cassetter.cassette import NoMatchError
+from cassetter.intercept._shared import apply_before_record_request, body_to_bytes
 
 
 class Urllib3Interceptor:
@@ -44,13 +44,12 @@ class Urllib3Interceptor:
             norm_headers = extract_headers(headers)
             norm_body = body.encode() if isinstance(body, str) else body
 
-            hook = cassette.before_record_request
-            if hook is not None:
-                try:
-                    raw = hook(RawRequest(norm_method, full_url, norm_headers, norm_body))
-                except SkipRecording:
-                    return original_urlopen(pool, method, url, body=body, headers=headers, **kwargs)  # type: ignore[return-value]
-                norm_method, full_url, norm_headers, norm_body = raw.method, raw.uri, raw.headers, raw.body
+            raw = apply_before_record_request(
+                cassette.before_record_request, norm_method, full_url, norm_headers, norm_body
+            )
+            if raw is None:
+                return original_urlopen(pool, method, url, body=body, headers=headers, **kwargs)  # type: ignore[return-value]
+            norm_method, full_url, norm_headers, norm_body = raw.method, raw.uri, raw.headers, raw.body
 
             try:
                 response = cassette.play(norm_method, full_url, norm_headers, norm_body)
@@ -120,15 +119,7 @@ def extract_headers(headers: Any) -> dict[str, list[str]]:
 
 
 def build_urllib3_response(response: _HttpResponse, request_url: str) -> urllib3.response.HTTPResponse:
-    body = response.body
-    if body.body_type == "json":
-        content = json.dumps(body.content).encode()
-    elif body.body_type == "text":
-        content = body.content.encode() if isinstance(body.content, str) else b""
-    elif body.body_type == "binary":
-        content = body.content if isinstance(body.content, bytes) else b""
-    else:
-        content = b""
+    content = body_to_bytes(response.body)
 
     resp_headers = urllib3._collections.HTTPHeaderDict()
     for key, values in response.headers.items():


### PR DESCRIPTION
First step of the interceptor de-duplication from the maintainability audit (findings #1/#2). Two verbatim-duplicated blocks are extracted into `intercept/_shared.py`:

- **Body-to-bytes decoder** - the exact `if body.body_type == "json": json.dumps(...).encode() ...` block was copied byte-for-byte across all five HTTP interceptors' `build_*_response` functions. Now `body_to_bytes(body)`.
- **`before_record_request` hook handling** - the RawRequest construction + `SkipRecording` contract was duplicated at six sites (each interceptor, plus httpx sync+async). Now `apply_before_record_request(hook, ...)` returning the modified request or `None` to signal pass-through; each site keeps its own pass-through call.

**Design note:** JSON serialization stays in Python (`json.dumps`) rather than moving to a Rust `Body.to_bytes()`, deliberately. `json.dumps` emits `", "`/`": "` separators and `ensure_ascii=True` escaping; Rust's serde_json matches neither by default, so a Rust decoder would change replayed-response bytes for anyone asserting on them. The Python helper is a zero-behavior-change dedup.

Net: the header-extraction helpers are intentionally left per-interceptor (they have genuine per-library differences - `multi_items` vs `items`, str coercion, pyreqwest's single-value form). A fuller shared record/replay pipeline (sync+async orchestration with response-builder adapters) is a larger change worth its own PR.

488 tests pass, 100% coverage, ruff/mypy/fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)