### PR TITLE
Extract shared hex codec for binary cassette bodies

### DIFF
--- a/rust/src/body/hex.rs
+++ b/rust/src/body/hex.rs
@@ -1,0 +1,41 @@
+//! Hex encoding/decoding for binary cassette bodies.
+
+/// Encode bytes as a lowercase hex string.
+pub fn encode(data: &[u8]) -> String {
+    data.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Decode a lowercase/uppercase hex string into bytes.
+pub fn decode(s: &str) -> Result<Vec<u8>, String> {
+    if !s.len().is_multiple_of(2) {
+        return Err("odd-length hex string".to_string());
+    }
+    if !s.is_ascii() {
+        return Err("non-ASCII hex string".to_string());
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        let data = vec![0u8, 1, 255, 16, 128];
+        assert_eq!(decode(&encode(&data)).unwrap(), data);
+    }
+
+    #[test]
+    fn test_odd_length_rejected() {
+        assert!(decode("abc").is_err());
+    }
+
+    #[test]
+    fn test_non_ascii_rejected() {
+        assert!(decode("ab€f").is_err());
+    }
+}

--- a/rust/src/body/mod.rs
+++ b/rust/src/body/mod.rs
@@ -1,4 +1,5 @@
 pub mod compression;
+pub mod hex;
 pub mod json;
 pub mod unicode;
 

--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -809,7 +809,7 @@ fn body_from_raw(raw: RawBody, binaries: &[Vec<u8>]) -> Body {
         }
         "binary" => {
             if let Some(Value::String(s)) = raw.content {
-                match hex_decode(&s) {
+                match crate::body::hex::decode(&s) {
                     Ok(bytes) => Body::binary(bytes),
                     Err(_) => Body::text(s),
                 }
@@ -833,30 +833,13 @@ fn body_to_raw(body: &Body) -> RawBody {
         },
         BodyContent::Binary(b) => RawBody {
             body_type: "binary".to_string(),
-            content: Some(Value::String(hex_encode(b))),
+            content: Some(Value::String(crate::body::hex::encode(b))),
         },
         BodyContent::None => RawBody {
             body_type: "none".to_string(),
             content: None,
         },
     }
-}
-
-fn hex_encode(data: &[u8]) -> String {
-    data.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
-    if !s.len().is_multiple_of(2) {
-        return Err("odd-length hex string".to_string());
-    }
-    if !s.is_ascii() {
-        return Err("non-ASCII hex string".to_string());
-    }
-    (0..s.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| e.to_string()))
-        .collect()
 }
 
 #[cfg(test)]

--- a/rust/src/cassette/format_toml.rs
+++ b/rust/src/cassette/format_toml.rs
@@ -127,7 +127,7 @@ fn body_to_toml(body: &Body) -> (String, Option<String>) {
             Some(serde_json::to_string(val).unwrap()),
         ),
         BodyContent::Text(s) => ("text".to_string(), Some(s.clone())),
-        BodyContent::Binary(b) => ("binary".to_string(), Some(hex_encode(b))),
+        BodyContent::Binary(b) => ("binary".to_string(), Some(crate::body::hex::encode(b))),
         BodyContent::None => ("none".to_string(), None),
     }
 }
@@ -151,7 +151,7 @@ fn body_from_toml(body_type: &str, content: Option<String>) -> Body {
         }
         "binary" => {
             if let Some(s) = content {
-                if let Ok(bytes) = hex_decode(&s) {
+                if let Ok(bytes) = crate::body::hex::decode(&s) {
                     return Body::binary(bytes);
                 }
             }
@@ -159,18 +159,4 @@ fn body_from_toml(body_type: &str, content: Option<String>) -> Body {
         }
         _ => Body::none(),
     }
-}
-
-fn hex_encode(data: &[u8]) -> String {
-    data.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
-    if !s.len().is_multiple_of(2) {
-        return Err("invalid hex length".to_string());
-    }
-    (0..s.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| format!("hex decode error: {e}")))
-        .collect()
 }


### PR DESCRIPTION
Removes a verbatim duplication flagged by the maintainability audit (finding #3): `hex_encode`/`hex_decode` were copied between `cassette/format.rs` and `cassette/format_toml.rs`.

- New `body/hex.rs` module with `encode`/`decode`, used by both format writers.
- The consolidated version keeps `format.rs`'s more robust `decode` (which rejects non-ASCII input with an `is_ascii` guard) - `format_toml.rs`'s copy lacked that guard, so TOML binary decoding is now equally hardened.
- Added unit tests for the codec (roundtrip, odd-length rejection, non-ASCII rejection).

Left intentionally per-format: the `body_to_raw`/`body_from_raw` (YAML) vs `body_to_toml`/`body_from_toml` conversions. They look similar but target genuinely different on-disk representations (YAML stores the JSON `Value` structurally + a binary-sentinel mechanism; TOML stores JSON as a string), so unifying them would couple two formats that are meant to diverge.

34 Rust tests + 488 Python tests pass, 100% coverage, clippy/fmt/mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)