### PR TITLE
Update benchmark numbers to reflect the serde-saphyr backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ with use_cassette("cassette.toml"):
     ...
 ```
 
-TOML loads ~2x faster than YAML and produces ~12% smaller files.
+TOML loads ~2.8x faster than YAML and produces ~12% smaller files (saves are slower).
 
 ## Request matching
 
@@ -445,24 +445,26 @@ pytest --vcr-check-orphans=tests/cassettes/
 
 ## Performance
 
-Rust-powered YAML parsing and serialization is 3-6x faster than vcrpy (which uses PyYAML/libyaml):
+Cassetter's Rust core is faster than vcrpy (compared against vcrpy with libyaml, its fastest configuration) - roughly 2-3x on load and 7-12x on save:
 
 ```
   1000 interactions
-                    cassetter    vcrpy         speedup
-  load              13.53 ms          58.90 ms      4.4x
-  match             0.98 ms           1.29 ms       1.3x
-  save              7.58 ms           45.64 ms      6.0x
+                    cassetter    vcrpy        speedup
+  load              35 ms        96 ms        2.7x
+  match             1.3 ms       1.85 ms      1.4x
+  save              6.5 ms       77 ms        11.8x
 ```
 
-TOML cassettes (`.toml`) load ~2x faster than YAML and produce ~12% smaller files:
+Absolute timings are machine dependent; the speedup ratios are the portable part. Load speedup also depends on cassette shape: many small interactions (as above) is the hardest case for the parser, while cassettes with large bodies (e.g. LLM/SSE responses) load proportionally faster.
+
+TOML cassettes (`.toml`) load ~2.8x faster than YAML and produce ~12% smaller files (at the cost of slower saves):
 
 ```
   1000 interactions
                       YAML         TOML
-  save                10.59 ms     11.67 ms
-  load                18.99 ms      9.79 ms
-  size                768.0 KB     675.3 KB
+  save                10.7 ms      18.0 ms
+  load                53 ms        18.6 ms
+  size                768 KB       675 KB
 ```
 
 Run `uv run python benchmarks/bench.py` and `uv run python benchmarks/bench_formats.py` to reproduce.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,29 +4,29 @@ Cassette parsing, matching, and serialization run in Rust, through a PyO3 extens
 
 ## Benchmarks
 
-Compared with VCR.py (which uses PyYAML with libyaml), on a cassette with 1000 interactions:
+Compared with VCR.py (using its fastest configuration, PyYAML with libyaml), on a cassette with 1000 interactions:
 
 ```
                 cassetter    vcrpy       speedup
-load            13.53 ms     58.90 ms    4.4x
-match           0.98 ms      1.29 ms     1.3x
-save            7.58 ms      45.64 ms    6.0x
+load            35 ms        96 ms       2.7x
+match           1.3 ms       1.85 ms     1.4x
+save            6.5 ms       77 ms       11.8x
 ```
 
-TOML cassettes load about 2 times faster than YAML and produce about 12% smaller files:
+Absolute timings are machine dependent, so the speedup ratios matter more than the raw numbers. Load speedup also depends on cassette shape: many tiny interactions (as above) is the hardest case for the parser, while cassettes dominated by large bodies - LLM and SSE responses, for example - load proportionally faster.
+
+TOML cassettes load about 2.8 times faster than YAML and produce about 12% smaller files, at the cost of slower saves:
 
 ```
                 YAML         TOML
-save            10.59 ms     11.67 ms
-load            18.99 ms     9.79 ms
-size            768.0 KB     675.3 KB
+save            10.7 ms      18.0 ms
+load            53 ms        18.6 ms
+size            768 KB       675 KB
 ```
 
 ## Why it matters
 
-A single cassette load taking 50 ms sounds harmless. Now multiply it by 500 tests, each loading a cassette in its setup. That is 25 seconds of pure parsing overhead per test run, before a single assertion executes.
-
-At Cassetter's speed the same suite spends about 7 seconds parsing, and switching the large cassettes to TOML brings it further down.
+Saves are 7 to 12 times faster than VCR.py, which matters when you re-record. Loads run on every test: a cassette-heavy suite that spends seconds in VCR.py's parser spends a fraction of that here, and switching large cassettes to TOML cuts load time further.
 
 ## Reproduce the numbers
 


### PR DESCRIPTION
The README and docs still quoted benchmark numbers from before the serde-saphyr swap (#36), which overstated load performance.

Re-ran `benchmarks/bench.py` and `benchmarks/bench_formats.py` on a release build (confirmed stable across runs) and updated `README.md` + `docs/performance.md`:

- **vcrpy comparison (1000 interactions):** the old table claimed load `13.53 ms` / `4.4x`. Actual is ~`35 ms` / `2.7x`. Save is `~6.5 ms` / `11.8x` (was `7.58 ms` / `6.0x`), match `~1.4x`. Headline changed from "3-6x faster" to the honest "2-3x on load and 7-12x on save."
- **TOML vs YAML:** "~2x faster load" is now ~2.8x; added the caveat that TOML saves are slower (it was implied but not stated). Sizes unchanged (768/675 KB).
- Added a note that absolute timings are machine-dependent (ratios are the portable part) and that load speedup varies with cassette shape - the many-tiny-interactions synthetic is the parser's worst case, while large-body cassettes (LLM/SSE) load proportionally faster.

The direction of the correction is honest: serde-saphyr traded some raw parse speed on this synthetic shape for security guarantees, active maintenance, and faster loads on large-body cassettes (measured 2.5x faster than the old backend on the pydantic-ai corpus). Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)