### PR TITLE
Add a reusable `Cassetter` configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ with recorder.use_cassette("openai.yaml", record_mode="all"):
     ...
 ```
 
-It takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against. The object is immutable and callable, so `recorder("openai.yaml")` works too.
+It takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against. The object is frozen and callable, so `recorder("openai.yaml")` works too.
 
 The `vcr_config` fixture accepts a `Cassetter`, so one object can configure both the pytest suite and direct `use_cassette()` calls:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,38 @@ with use_cassette("tests/cassettes/my_test.yaml", record_mode="once"):
         response = await client.get("https://api.example.com/users")
 ```
 
+### With a reusable configuration
+
+`Cassetter` holds the options shared by a group of cassettes, so they are declared once instead of on every call:
+
+```python
+from cassetter import Cassetter
+
+recorder = Cassetter(
+    cassette_library_dir="tests/cassettes",
+    record_mode="none",
+    filter_headers=["x-gateway-apikey"],
+    before_record_request=my_request_hook,
+)
+
+with recorder.use_cassette("openai.yaml"):
+    ...
+
+# override any option for a single cassette
+with recorder.use_cassette("openai.yaml", record_mode="all"):
+    ...
+```
+
+It takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against. The object is immutable and callable, so `recorder("openai.yaml")` works too.
+
+The `vcr_config` fixture accepts a `Cassetter`, so one object can configure both the pytest suite and direct `use_cassette()` calls:
+
+```python
+@pytest.fixture(scope="module")
+def vcr_config() -> Cassetter:
+    return recorder
+```
+
 ## Record modes
 
 | Mode | Behavior |
@@ -508,6 +540,7 @@ cassetter uses the same `@pytest.mark.vcr` marker, `vcr_config` fixture, and `--
 | pytest-recording / VCR.py | cassetter | Notes |
 |---|---|---|
 | `vcr` fixture | `cassette` fixture | `vcr` is available as an alias |
+| `vcr.VCR(...)` | `Cassetter(...)` | Same idea, same `cassette_library_dir` |
 | `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
 | `decode_compressed_response` | _(automatic)_ | Always decompresses - no config needed |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -217,7 +217,32 @@ When `record_mode=none` and a cassette file doesn't exist, the fixture creates a
 
 **Why this choice:** Module-level VCR markers are convenient for test files where most-but-not-all tests need recording. Non-recording tests shouldn't be forced to have empty cassette files.
 
-## 7. Scope and non-goals
+## 7. Configuration object
+
+`Cassetter` is a frozen dataclass holding the options shared by a group of cassettes. It exposes `use_cassette(name, **overrides)`, and `cassette_library_dir` - the directory cassette names are resolved against.
+
+```python
+recorder = Cassetter(cassette_library_dir="tests/cassettes", record_mode="none")
+
+with recorder.use_cassette("openai.yaml"):
+    ...
+```
+
+Both entry points build cassettes through it: `use_cassette()` is a thin wrapper that constructs one, and the pytest plugin converts a `vcr_config` dictionary into one. There is a single place where options become a `Cassette`.
+
+**Alternatives considered:**
+
+- **A `VCR`-named class (VCR.py's `vcr.VCR(...)`).** Maximum familiarity, but cassetter is positioned as a replacement for VCR.py - reusing the name makes documentation and stack traces ambiguous about which library is in play. Rejected because the cost outlives the migration.
+
+- **Making `use_cassette()` itself the factory** (`my_vcr = use_cassette(...)`, then `with my_vcr(...)`). One name for two roles: called with a path it records, called without one it configures. The return type depends on the arguments, which neither type checkers nor readers handle well. Rejected because the overload is not worth the saved name.
+
+- **Turning the `CassetteConfig` TypedDict into the object.** `vcr_config` already returns a dictionary in existing suites and in pytest-recording, so the mapping form has to keep working regardless. Keeping the TypedDict for the mapping and adding a separate class avoids breaking those fixtures. Rejected because it renames a working type for no gain.
+
+- **Mutable configuration.** A configuration shared across a test suite is exactly the kind of object one test mutates and another test pays for. Frozen plus per-call `**overrides` (and `dataclasses.replace` for a derived configuration) covers the same use cases without the failure mode. Rejected because shared mutable defaults are a known source of test-order bugs.
+
+**Why this choice:** Configuration is data, so it gets a value object rather than a builder or a factory function. Options unset on the object fall back to the same defaults as `use_cassette()`, which keeps one set of defaults in the library. The one deliberate exception is `record_mode`, which is stored as "unset" rather than `once`: the pytest plugin defaults to `none` for safety, and an object that silently flipped a suite to `once` would defeat that.
+
+## 8. Scope and non-goals
 
 ### Implemented
 - HTTP recording/replay for httpx, aiohttp, requests, urllib3

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -238,7 +238,9 @@ Both entry points build cassettes through it: `use_cassette()` is a thin wrapper
 
 - **Turning the `CassetteConfig` TypedDict into the object.** `vcr_config` already returns a dictionary in existing suites and in pytest-recording, so the mapping form has to keep working regardless. Keeping the TypedDict for the mapping and adding a separate class avoids breaking those fixtures. Rejected because it renames a working type for no gain.
 
-- **Mutable configuration.** A configuration shared across a test suite is exactly the kind of object one test mutates and another test pays for. Frozen plus per-call `**overrides` (and `dataclasses.replace` for a derived configuration) covers the same use cases without the failure mode. Rejected because shared mutable defaults are a known source of test-order bugs.
+- **Mutable configuration.** A configuration shared across a test suite is exactly the kind of object one test mutates and another test pays for. Frozen plus per-call `**overrides` (and `dataclasses.replace` for a derived configuration) covers the same use cases without an API that invites it. Rejected because shared mutable defaults are a known source of test-order bugs.
+
+  Frozen is shallow, as everywhere else in Python: the option lists themselves are still lists, and mutating one in place is visible to cassettes built afterwards. Normalizing them to tuples was considered and rejected - it would hand back a tuple for a list the caller passed, breaking equality against the value they wrote, in exchange for closing a hole nobody reaches into.
 
 **Why this choice:** Configuration is data, so it gets a value object rather than a builder or a factory function. Options unset on the object fall back to the same defaults as `use_cassette()`, which keeps one set of defaults in the library. The one deliberate exception is `record_mode`, which is stored as "unset" rather than `once`: the pytest plugin defaults to `none` for safety, and an object that silently flipped a suite to `once` would defeat that.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,6 +37,7 @@ $ pytest
 | pytest-recording / VCR.py | Cassetter | Notes |
 |---|---|---|
 | `vcr` fixture | `cassette` fixture | `vcr` still works as an alias |
+| `vcr.VCR(...)` | [`Cassetter(...)`](tutorial/configuration.md) | Same idea, same `cassette_library_dir`, and it can be returned from `vcr_config` |
 | `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
 | `before_record_request` | `before_record_request` | Same name, same behavior |

--- a/docs/tutorial/configuration.md
+++ b/docs/tutorial/configuration.md
@@ -47,7 +47,7 @@ with recorder.use_cassette("openai.yaml", record_mode="all"):
     ...  # re-records this one cassette
 ```
 
-`Cassetter` is immutable, so a configuration shared between tests can never be modified by one of them. To derive a new configuration instead of overriding a single call, use `dataclasses.replace`:
+`Cassetter` is frozen, so no test can reassign an option on a configuration another test shares. To derive a new configuration instead of overriding a single call, use `dataclasses.replace`:
 
 ```python
 from dataclasses import replace

--- a/docs/tutorial/configuration.md
+++ b/docs/tutorial/configuration.md
@@ -1,0 +1,79 @@
+# Reuse a configuration
+
+Passing the same options to every `use_cassette()` call gets old fast. `Cassetter` holds them once:
+
+```python
+from cassetter import Cassetter
+
+recorder = Cassetter(
+    cassette_library_dir="tests/cassettes",
+    record_mode="none",
+    filter_headers=["x-gateway-apikey"],
+    match_on=["method", "uri", "json_body"],
+)
+
+with recorder.use_cassette("openai.yaml"):
+    ...
+
+with recorder.use_cassette("anthropic.yaml"):
+    ...
+```
+
+It accepts every option `use_cassette()` accepts, plus `cassette_library_dir`. Anything you leave out keeps its default.
+
+The object is callable, so `recorder("openai.yaml")` is the same as `recorder.use_cassette("openai.yaml")`.
+
+## Where the cassettes go
+
+`cassette_library_dir` is the directory cassette names are resolved against:
+
+```python
+recorder = Cassetter(cassette_library_dir="src/evals/cassettes")
+
+with recorder.use_cassette("openai.yaml"):  # src/evals/cassettes/openai.yaml
+    ...
+```
+
+Names can include subdirectories, and an absolute path is used as is. Without `cassette_library_dir`, the name is the path, exactly like `use_cassette()`.
+
+## Override one cassette
+
+Keyword arguments to `use_cassette()` replace the configured value for that cassette only:
+
+```python
+recorder = Cassetter(cassette_library_dir="tests/cassettes", record_mode="none")
+
+with recorder.use_cassette("openai.yaml", record_mode="all"):
+    ...  # re-records this one cassette
+```
+
+`Cassetter` is immutable, so a configuration shared between tests can never be modified by one of them. To derive a new configuration instead of overriding a single call, use `dataclasses.replace`:
+
+```python
+from dataclasses import replace
+
+recording = replace(recorder, record_mode="all")
+```
+
+## Share it with pytest
+
+The `vcr_config` fixture accepts a `Cassetter`, so the same object drives both the marked tests and any direct `use_cassette()` call:
+
+```python
+# tests/conftest.py
+import pytest
+
+from cassetter import Cassetter
+
+RECORDER = Cassetter(record_mode="none", filter_headers=["x-gateway-apikey"])
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> Cassetter:
+    return RECORDER
+```
+
+Two things behave differently under pytest, matching what the plugin already does with a dictionary:
+
+* An unset `record_mode` means `none`, not `once`. Cassettes never record unless you pass `--record-mode`.
+* `cassette_library_dir`, when set, replaces the [`vcr_cassette_dir`](pytest.md#customize-the-cassette-directory) fixture, so cassettes are not grouped per test module. A `cassette_dir` on the marker still wins.

--- a/docs/tutorial/context-manager.md
+++ b/docs/tutorial/context-manager.md
@@ -50,6 +50,9 @@ with use_cassette(
 
 Each option has its own section in this tutorial. The important thing to remember: **you only need the path**. Everything else has safe defaults.
 
+!!! tip
+    To declare these options once and reuse them across many cassettes, see [Reuse a configuration](configuration.md).
+
 ## Select the intercepted libraries
 
 By default, Cassetter detects which HTTP libraries are installed and intercepts all of them. To limit interception to specific libraries, pass `intercept`:

--- a/docs/tutorial/pytest.md
+++ b/docs/tutorial/pytest.md
@@ -100,6 +100,7 @@ The supported keys are the same options accepted by `use_cassette()`:
 | `body_scrub_patterns` | Body field patterns scrubbed from cassettes |
 | `filter_replacement` | Replacement string for filtered values |
 | `cassette_dir` | Cassette directory, relative to the test file |
+| `cassette_library_dir` | Cassette directory, used as is |
 | `intercept` | Libraries to intercept |
 | `max_age` | Cassette expiry, e.g. `"30d"` |
 | `on_expiry` | What to do with expired cassettes |
@@ -107,6 +108,17 @@ The supported keys are the same options accepted by `use_cassette()`:
 | `ignore_hosts` | Bypass requests to matching hosts |
 | `before_record_request` | Hook to modify or skip requests |
 | `before_record_response` | Hook to modify or skip responses |
+
+The fixture can also return a [`Cassetter`](configuration.md), which is the same set of options as an object, shareable with code that calls `use_cassette()` directly:
+
+```python
+from cassetter import Cassetter
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> Cassetter:
+    return Cassetter(record_mode="once", filter_headers=["x-custom-secret"])
+```
 
 ## Configure per test
 

--- a/src/cassetter/__init__.py
+++ b/src/cassetter/__init__.py
@@ -25,6 +25,7 @@ from cassetter.cassette import (
     RawResponse,
     SkipRecording,
 )
+from cassetter.config import Cassetter
 from cassetter.context import use_cassette
 from cassetter.introspection import RecordedRequest
 from cassetter.recording import RecordMode
@@ -37,6 +38,7 @@ __all__ = [
     "CassetteExpiredError",
     "CassetteExpiredWarning",
     "CassetteNotFoundError",
+    "Cassetter",
     "GrpcInteraction",
     "GrpcRequest",
     "GrpcResponse",

--- a/src/cassetter/_types.py
+++ b/src/cassetter/_types.py
@@ -16,6 +16,7 @@ class CassetteConfig(TypedDict, total=False):
     body_scrub_patterns: list[str]
     filter_replacement: str
     cassette_dir: str
+    cassette_library_dir: str
     intercept: list[str]
     max_age: str
     on_expiry: str

--- a/src/cassetter/config.py
+++ b/src/cassetter/config.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, replace
+from typing import Any
+
+from cassetter._core import MatchConfig, SecurityConfig
+from cassetter._state import acquire_patches, current_cassette, release_patches
+from cassetter.cassette import BeforeRecordRequest, BeforeRecordResponse, Cassette
+from cassetter.intercept._registry import resolve_interceptors
+from cassetter.recording import RecordMode
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Cassetter:
+    """Reusable cassette configuration.
+
+    Holds the options shared by a group of cassettes so they are declared once instead of on every
+    `use_cassette()` call:
+
+    ```python
+    recorder = Cassetter(cassette_library_dir="tests/cassettes", record_mode="none")
+
+    with recorder.use_cassette("openai.yaml") as cassette:
+        ...
+    ```
+
+    Options left unset fall back to the same defaults as `use_cassette()`.
+    """
+
+    cassette_library_dir: str | os.PathLike[str] | None = None
+    record_mode: RecordMode | str | None = None
+    match_on: list[str] | None = None
+    ignore_json_paths: list[str] | None = None
+    filter_headers: list[str] | None = None
+    filter_query_parameters: list[str] | None = None
+    body_scrub_patterns: list[str] | None = None
+    filter_replacement: str | None = None
+    intercept: list[str] | None = None
+    max_age: str | None = None
+    on_expiry: str | None = None
+    ignore_localhost: bool = False
+    ignore_hosts: list[str] | None = None
+    before_record_request: BeforeRecordRequest | None = None
+    before_record_response: BeforeRecordResponse | None = None
+
+    def cassette(self, name: str | os.PathLike[str]) -> Cassette:
+        """Build an unloaded cassette for `name`, resolved against `cassette_library_dir`.
+
+        Args:
+            name: Cassette file name, or a path. Absolute paths ignore `cassette_library_dir`.
+
+        Returns:
+            A cassette that has not read its file yet - call `load()` before using it.
+        """
+        record_mode = RecordMode.ONCE if self.record_mode is None else self.record_mode
+        library_dir = self.cassette_library_dir
+        path = os.fspath(name) if library_dir is None else os.path.join(library_dir, os.fspath(name))
+        return Cassette(
+            path,
+            record_mode=RecordMode.from_str(record_mode) if isinstance(record_mode, str) else record_mode,
+            match_config=MatchConfig(match_on=self.match_on, ignore_json_paths=self.ignore_json_paths),
+            security_config=SecurityConfig(
+                filter_headers=self.filter_headers,
+                filter_query_parameters=self.filter_query_parameters,
+                body_scrub_patterns=self.body_scrub_patterns,
+                replacement=self.filter_replacement,
+            ),
+            max_age=self.max_age,
+            on_expiry="warn" if self.on_expiry is None else self.on_expiry,
+            ignore_localhost=self.ignore_localhost,
+            ignore_hosts=self.ignore_hosts,
+            before_record_request=self.before_record_request,
+            before_record_response=self.before_record_response,
+        )
+
+    @contextlib.contextmanager
+    def use_cassette(self, name: str | os.PathLike[str], **overrides: Any) -> Iterator[Cassette]:
+        """Record/replay HTTP interactions into `name`.
+
+        Args:
+            name: Cassette file name, or a path. Absolute paths ignore `cassette_library_dir`.
+            overrides: Any option of this configuration, replaced for this cassette only.
+        """
+        config = replace(self, **overrides) if overrides else self
+        cassette = config.cassette(name)
+        cassette.load()
+
+        interceptor_classes = resolve_interceptors(config.intercept)
+
+        acquire_patches(interceptor_classes)
+        token = current_cassette.set(cassette)
+
+        try:
+            yield cassette
+        finally:
+            current_cassette.reset(token)
+            release_patches(interceptor_classes)
+            cassette.save()
+
+    __call__ = use_cassette

--- a/src/cassetter/context.py
+++ b/src/cassetter/context.py
@@ -1,75 +1,13 @@
 from __future__ import annotations
 
-import contextlib
 import os
-from collections.abc import Iterator
-from typing import Any
+from contextlib import AbstractContextManager
 
-from cassetter._core import MatchConfig, SecurityConfig
-from cassetter._state import acquire_patches, current_cassette, release_patches
 from cassetter.cassette import BeforeRecordRequest, BeforeRecordResponse, Cassette
-from cassetter.intercept._base import InterceptorProtocol
+from cassetter.config import Cassetter
 from cassetter.recording import RecordMode
 
-try:
-    from cassetter.intercept._httpx import HttpxInterceptor
-except ImportError:  # pragma: no cover
-    HttpxInterceptor = None  # type: ignore[assignment]
 
-try:
-    from cassetter.intercept._httpx2 import Httpx2Interceptor
-except ImportError:  # pragma: no cover
-    Httpx2Interceptor = None  # type: ignore[assignment]
-
-try:
-    from cassetter.intercept._aiohttp import AiohttpInterceptor
-except ImportError:  # pragma: no cover
-    AiohttpInterceptor = None  # type: ignore[assignment, misc]
-
-try:
-    from cassetter.intercept._requests import RequestsInterceptor
-except ImportError:  # pragma: no cover
-    RequestsInterceptor = None  # type: ignore[assignment, misc]
-
-try:
-    from cassetter.intercept._grpc import GrpcInterceptor
-except ImportError:  # pragma: no cover
-    GrpcInterceptor = None  # type: ignore[assignment, misc]
-
-try:
-    from cassetter.intercept._websockets import WebSocketInterceptor
-except ImportError:  # pragma: no cover
-    WebSocketInterceptor = None  # type: ignore[assignment, misc]
-
-try:
-    from cassetter.intercept._urllib3 import Urllib3Interceptor
-except ImportError:  # pragma: no cover
-    Urllib3Interceptor = None  # type: ignore[assignment, misc]
-
-try:
-    from cassetter.intercept._pyreqwest import PyreqwestInterceptor
-except ImportError:  # pragma: no cover
-    PyreqwestInterceptor = None  # type: ignore[assignment, misc]
-
-_INTERCEPTOR_MAP: dict[str, type[InterceptorProtocol] | None] = {
-    "httpx": HttpxInterceptor,
-    "httpx2": Httpx2Interceptor,
-    "aiohttp": AiohttpInterceptor,
-    "requests": RequestsInterceptor,
-    "grpc": GrpcInterceptor,
-    "websockets": WebSocketInterceptor,
-    "urllib3": Urllib3Interceptor,
-    "pyreqwest": PyreqwestInterceptor,
-}
-
-# Interceptors auto-detected by default, in order. requests is intentionally
-# omitted: requests traffic flows through urllib3, so recording both layers
-# would capture each request twice. Callers who want requests can name it
-# explicitly.
-_AUTO_DETECT_ORDER: list[str] = ["httpx", "httpx2", "urllib3", "aiohttp"]
-
-
-@contextlib.contextmanager
 def use_cassette(
     path: str | os.PathLike[str],
     *,
@@ -87,7 +25,7 @@ def use_cassette(
     ignore_hosts: list[str] | None = None,
     before_record_request: BeforeRecordRequest | None = None,
     before_record_response: BeforeRecordResponse | None = None,
-) -> Iterator[Cassette]:
+) -> AbstractContextManager[Cassette]:
     """Context manager for recording/replaying HTTP interactions.
 
     Args:
@@ -100,28 +38,25 @@ def use_cassette(
         body_scrub_patterns: Body patterns to scrub.
         filter_replacement: Replacement string for filtered values.
         intercept: HTTP libraries to intercept (default: auto-detect).
+        max_age: Maximum cassette age before it is considered expired, e.g. "30d".
+        on_expiry: What to do with an expired cassette: "warn", "fail", or "rerecord".
+        ignore_localhost: Bypass the cassette for requests to localhost.
+        ignore_hosts: Bypass the cassette for requests to matching hosts.
+        before_record_request: Hook to modify or skip requests.
+        before_record_response: Hook to modify or skip responses.
+
+    Returns:
+        A context manager yielding the active cassette.
     """
-    if isinstance(record_mode, str):
-        record_mode = RecordMode.from_str(record_mode)
-
-    match_config = MatchConfig(match_on=match_on, ignore_json_paths=ignore_json_paths)
-
-    security_kwargs: dict[str, Any] = {}
-    if filter_headers is not None:
-        security_kwargs["filter_headers"] = filter_headers
-    if filter_query_parameters is not None:
-        security_kwargs["filter_query_parameters"] = filter_query_parameters
-    if body_scrub_patterns is not None:
-        security_kwargs["body_scrub_patterns"] = body_scrub_patterns
-    if filter_replacement is not None:
-        security_kwargs["replacement"] = filter_replacement
-    security_config = SecurityConfig(**security_kwargs)
-
-    cassette = Cassette(
-        path,
+    config = Cassetter(
         record_mode=record_mode,
-        match_config=match_config,
-        security_config=security_config,
+        match_on=match_on,
+        ignore_json_paths=ignore_json_paths,
+        filter_headers=filter_headers,
+        filter_query_parameters=filter_query_parameters,
+        body_scrub_patterns=body_scrub_patterns,
+        filter_replacement=filter_replacement,
+        intercept=intercept,
         max_age=max_age,
         on_expiry=on_expiry,
         ignore_localhost=ignore_localhost,
@@ -129,46 +64,4 @@ def use_cassette(
         before_record_request=before_record_request,
         before_record_response=before_record_response,
     )
-    cassette.load()
-
-    interceptor_classes = resolve_interceptors(intercept)
-
-    acquire_patches(interceptor_classes)
-    token = current_cassette.set(cassette)
-
-    try:
-        yield cassette
-    finally:
-        current_cassette.reset(token)
-        release_patches(interceptor_classes)
-        cassette.save()
-
-
-def resolve_interceptors(names: list[str] | None = None) -> list[type[InterceptorProtocol]]:
-    """Import and return interceptor classes by name, or auto-detect if None."""
-    if names is None:
-        return _auto_detect_interceptors()
-    # An explicit list installs exactly what was requested. requests and
-    # urllib3 overlap (requests flows through urllib3), but a session with a
-    # custom adapter may not, so dropping a requested interceptor could
-    # silently bypass the cassette. Auto-detect avoids the overlap instead.
-    interceptors: list[type[InterceptorProtocol]] = []
-    for name in names:
-        cls = _INTERCEPTOR_MAP.get(name)
-        if cls is None:
-            if name in _INTERCEPTOR_MAP:
-                raise ImportError(f"interceptor {name!r} requires installing the '{name}' extra")
-            raise ValueError(f"unknown interceptor: {name!r}")
-        interceptors.append(cls)
-    return interceptors
-
-
-def _auto_detect_interceptors() -> list[type[InterceptorProtocol]]:
-    """Detect installed HTTP libraries and return interceptor classes for all of them."""
-    available: list[str] = []
-    for name in _AUTO_DETECT_ORDER:
-        if _INTERCEPTOR_MAP.get(name) is not None:
-            available.append(name)
-    if not available:
-        raise ImportError("no HTTP interceptors available - install httpx, httpx2, urllib3, or aiohttp")
-    return [_INTERCEPTOR_MAP[name] for name in available]  # type: ignore[misc]
+    return config.use_cassette(path)

--- a/src/cassetter/intercept/_registry.py
+++ b/src/cassetter/intercept/_registry.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from cassetter.intercept._base import InterceptorProtocol
+
+try:
+    from cassetter.intercept._httpx import HttpxInterceptor
+except ImportError:  # pragma: no cover
+    HttpxInterceptor = None  # type: ignore[assignment]
+
+try:
+    from cassetter.intercept._httpx2 import Httpx2Interceptor
+except ImportError:  # pragma: no cover
+    Httpx2Interceptor = None  # type: ignore[assignment]
+
+try:
+    from cassetter.intercept._aiohttp import AiohttpInterceptor
+except ImportError:  # pragma: no cover
+    AiohttpInterceptor = None  # type: ignore[assignment, misc]
+
+try:
+    from cassetter.intercept._requests import RequestsInterceptor
+except ImportError:  # pragma: no cover
+    RequestsInterceptor = None  # type: ignore[assignment, misc]
+
+try:
+    from cassetter.intercept._grpc import GrpcInterceptor
+except ImportError:  # pragma: no cover
+    GrpcInterceptor = None  # type: ignore[assignment, misc]
+
+try:
+    from cassetter.intercept._websockets import WebSocketInterceptor
+except ImportError:  # pragma: no cover
+    WebSocketInterceptor = None  # type: ignore[assignment, misc]
+
+try:
+    from cassetter.intercept._urllib3 import Urllib3Interceptor
+except ImportError:  # pragma: no cover
+    Urllib3Interceptor = None  # type: ignore[assignment, misc]
+
+try:
+    from cassetter.intercept._pyreqwest import PyreqwestInterceptor
+except ImportError:  # pragma: no cover
+    PyreqwestInterceptor = None  # type: ignore[assignment, misc]
+
+_INTERCEPTOR_MAP: dict[str, type[InterceptorProtocol] | None] = {
+    "httpx": HttpxInterceptor,
+    "httpx2": Httpx2Interceptor,
+    "aiohttp": AiohttpInterceptor,
+    "requests": RequestsInterceptor,
+    "grpc": GrpcInterceptor,
+    "websockets": WebSocketInterceptor,
+    "urllib3": Urllib3Interceptor,
+    "pyreqwest": PyreqwestInterceptor,
+}
+
+# Interceptors auto-detected by default, in order. requests is intentionally
+# omitted: requests traffic flows through urllib3, so recording both layers
+# would capture each request twice. Callers who want requests can name it
+# explicitly.
+_AUTO_DETECT_ORDER: list[str] = ["httpx", "httpx2", "urllib3", "aiohttp"]
+
+
+def resolve_interceptors(names: list[str] | None = None) -> list[type[InterceptorProtocol]]:
+    """Import and return interceptor classes by name, or auto-detect if None."""
+    if names is None:
+        return _auto_detect_interceptors()
+    # An explicit list installs exactly what was requested. requests and
+    # urllib3 overlap (requests flows through urllib3), but a session with a
+    # custom adapter may not, so dropping a requested interceptor could
+    # silently bypass the cassette. Auto-detect avoids the overlap instead.
+    interceptors: list[type[InterceptorProtocol]] = []
+    for name in names:
+        cls = _INTERCEPTOR_MAP.get(name)
+        if cls is None:
+            if name in _INTERCEPTOR_MAP:
+                raise ImportError(f"interceptor {name!r} requires installing the '{name}' extra")
+            raise ValueError(f"unknown interceptor: {name!r}")
+        interceptors.append(cls)
+    return interceptors
+
+
+def _auto_detect_interceptors() -> list[type[InterceptorProtocol]]:
+    """Detect installed HTTP libraries and return interceptor classes for all of them."""
+    available: list[str] = []
+    for name in _AUTO_DETECT_ORDER:
+        if _INTERCEPTOR_MAP.get(name) is not None:
+            available.append(name)
+    if not available:
+        raise ImportError("no HTTP interceptors available - install httpx, httpx2, urllib3, or aiohttp")
+    return [_INTERCEPTOR_MAP[name] for name in available]  # type: ignore[misc]

--- a/src/cassetter/pytest_plugin/fixtures.py
+++ b/src/cassetter/pytest_plugin/fixtures.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
+from dataclasses import fields, replace
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from cassetter._core import MatchConfig, SecurityConfig
 from cassetter._state import acquire_patches, current_cassette, release_patches
 from cassetter._types import CassetteConfig
 from cassetter.cassette import Cassette
-from cassetter.context import resolve_interceptors
+from cassetter.config import Cassetter
 from cassetter.intercept._base import InterceptorProtocol
-from cassetter.recording import RecordMode
+from cassetter.intercept._registry import resolve_interceptors
+
+_CASSETTER_FIELDS = {field.name for field in fields(Cassetter)}
 
 
 @pytest.fixture(scope="module")
-def vcr_config() -> CassetteConfig:
+def vcr_config() -> CassetteConfig | Cassetter:
     """Override this fixture to provide default VCR configuration."""
     return CassetteConfig()
 
@@ -33,11 +35,20 @@ def vcr_cassette_dir(request: pytest.FixtureRequest) -> str:
     return str(test_file.parent / "cassettes" / test_file.stem)
 
 
+def _split_config(vcr_config: CassetteConfig | Cassetter) -> tuple[Cassetter, str | None]:
+    """Split a `vcr_config` value into a configuration and the test-relative `cassette_dir`."""
+    if isinstance(vcr_config, Cassetter):
+        return vcr_config, None
+    options: Mapping[str, Any] = vcr_config
+    known = {name: value for name, value in options.items() if name in _CASSETTER_FIELDS}
+    return Cassetter(**known), options.get("cassette_dir")
+
+
 def _resolve_cassette(
     node_name: str,
     marker_args: tuple[Any, ...],
     marker_kwargs: dict[str, Any],
-    vcr_config: CassetteConfig,
+    vcr_config: CassetteConfig | Cassetter,
     cli_record_mode: str | None,
     test_fspath: str,
     vcr_cassette_dir: str | None = None,
@@ -45,85 +56,47 @@ def _resolve_cassette(
     ini_on_expiry: str | None = None,
 ) -> tuple[Cassette, list[type[InterceptorProtocol]]]:
     """Resolve cassette configuration and create a Cassette instance."""
-    cassette_name = node_name + ".yaml"
-    record_mode_str = vcr_config.get("record_mode", "none")
+    config, config_cassette_dir = _split_config(vcr_config)
 
-    # Marker can override
-    if marker_args:
-        cassette_name = marker_args[0]
+    cassette_name = marker_args[0] if marker_args else node_name + ".yaml"
+
+    record_mode = config.record_mode or "none"
     if "record_mode" in marker_kwargs:
-        record_mode_str = marker_kwargs["record_mode"]
-
-    # CLI override
+        record_mode = marker_kwargs["record_mode"]
     if cli_record_mode is not None:
-        record_mode_str = cli_record_mode
+        record_mode = cli_record_mode
 
-    record_mode = RecordMode.from_str(record_mode_str)
+    test_file = Path(test_fspath)
+    test_dir = str(test_file.parent)
 
-    # Resolve cassette directory: vcr_cassette_dir fixture > marker > vcr_config > default
+    # marker > cassette_library_dir > vcr_cassette_dir fixture > vcr_config > default
     if "cassette_dir" in marker_kwargs:
-        test_file = Path(test_fspath)
-        test_dir = str(test_file.parent)
         cassette_dir = os.path.join(test_dir, marker_kwargs["cassette_dir"], test_file.stem)
+    elif config.cassette_library_dir is not None:
+        cassette_dir = os.fspath(config.cassette_library_dir)
     elif vcr_cassette_dir is not None:
         cassette_dir = vcr_cassette_dir
-    elif "cassette_dir" in vcr_config:
-        test_file = Path(test_fspath)
-        test_dir = str(test_file.parent)
-        cassette_dir = os.path.join(test_dir, vcr_config["cassette_dir"], test_file.stem)
+    elif config_cassette_dir is not None:
+        cassette_dir = os.path.join(test_dir, config_cassette_dir, test_file.stem)
     else:  # pragma: no cover - the vcr_cassette_dir fixture always supplies a directory
-        test_file = Path(test_fspath)
-        test_dir = str(test_file.parent)
         cassette_dir = os.path.join(test_dir, "cassettes", test_file.stem)
 
-    cassette_path = os.path.join(cassette_dir, cassette_name)
-
-    match_config = MatchConfig(
-        match_on=vcr_config.get("match_on"),
-        ignore_json_paths=vcr_config.get("ignore_json_paths"),
-    )
-
-    security_kwargs: dict[str, Any] = {}
-    if "filter_headers" in vcr_config:
-        security_kwargs["filter_headers"] = vcr_config["filter_headers"]
-    if "filter_query_parameters" in vcr_config:
-        security_kwargs["filter_query_parameters"] = vcr_config["filter_query_parameters"]
-    if "body_scrub_patterns" in vcr_config:
-        security_kwargs["body_scrub_patterns"] = vcr_config["body_scrub_patterns"]
-    if "filter_replacement" in vcr_config:
-        security_kwargs["replacement"] = vcr_config["filter_replacement"]
-    security_config = SecurityConfig(**security_kwargs)
-
-    max_age = marker_kwargs.get("max_age", vcr_config.get("max_age", ini_max_age))
-    on_expiry = marker_kwargs.get("on_expiry", vcr_config.get("on_expiry", ini_on_expiry or "warn"))
-
-    ignore_localhost = vcr_config.get("ignore_localhost", False)
-    ignore_hosts = vcr_config.get("ignore_hosts")
-    before_record_request = vcr_config.get("before_record_request")
-    before_record_response = vcr_config.get("before_record_response")
-
-    cassette = Cassette(
-        cassette_path,
+    resolved = replace(
+        config,
+        cassette_library_dir=cassette_dir,
         record_mode=record_mode,
-        match_config=match_config,
-        security_config=security_config,
-        max_age=max_age,
-        on_expiry=on_expiry,
-        ignore_localhost=ignore_localhost,
-        ignore_hosts=ignore_hosts,
-        before_record_request=before_record_request,
-        before_record_response=before_record_response,
+        max_age=marker_kwargs.get("max_age", config.max_age or ini_max_age),
+        on_expiry=marker_kwargs.get("on_expiry", config.on_expiry or ini_on_expiry or "warn"),
     )
+    cassette = resolved.cassette(cassette_name)
     cassette.load()
 
-    intercept_names = vcr_config.get("intercept")
-    interceptor_classes = resolve_interceptors(intercept_names)
-    return cassette, interceptor_classes
+    return cassette, resolve_interceptors(config.intercept)
 
 
 @pytest.fixture(autouse=True)
 def cassette(
-    request: pytest.FixtureRequest, vcr_config: CassetteConfig, vcr_cassette_dir: str
+    request: pytest.FixtureRequest, vcr_config: CassetteConfig | Cassetter, vcr_cassette_dir: str
 ) -> Iterator[Cassette | None]:
     """Activates cassette recording/replay for tests marked with @pytest.mark.vcr."""
     marker = request.node.get_closest_marker("vcr")

--- a/tests/cassettes/test_config_marker/test_vcr_config_accepts_a_cassetter.yaml
+++ b/tests/cassettes/test_config_marker/test_vcr_config_accepts_a_cassetter.yaml
@@ -1,0 +1,18 @@
+version: 1
+interactions:
+- request:
+    method: GET
+    uri: https://example.com/config-test
+    headers: {}
+    body:
+      type: none
+  response:
+    status: 200
+    headers:
+      content-type:
+      - application/json
+    body:
+      type: json
+      content:
+        config: true
+  recorded_at: 2026-01-01T00:00:00Z

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+from cassetter import Cassetter
+from cassetter._core import Body, Cassette as RustCassette, HttpInteraction, HttpRequest, HttpResponse
+from cassetter.cassette import CassetteExpiredError, CassetteExpiredWarning
+from cassetter.recording import RecordMode
+
+pytest_plugins = ("anyio",)
+
+
+def _make_cassette(path: str) -> str:
+    c = RustCassette()
+    c.add_interaction(
+        HttpInteraction(
+            request=HttpRequest("GET", "https://example.com/api"),
+            response=HttpResponse(200, {"content-type": ["application/json"]}, Body("json", {"ok": True})),
+            recorded_at="2026-01-01T00:00:00Z",
+        )
+    )
+    c.save(path)
+    return path
+
+
+def test_defaults_match_use_cassette() -> None:
+    cassette = Cassetter().cassette("test.yaml")
+    assert cassette.path == "test.yaml"
+    assert cassette.record_mode == RecordMode.ONCE
+
+
+def test_cassette_library_dir_is_joined() -> None:
+    cassette = Cassetter(cassette_library_dir="tests/cassettes").cassette("openai.yaml")
+    assert cassette.path == os.path.join("tests", "cassettes", "openai.yaml")
+
+
+def test_cassette_library_dir_accepts_path_like(tmp_path: Path) -> None:
+    cassette = Cassetter(cassette_library_dir=tmp_path).cassette("openai.yaml")
+    assert cassette.path == str(tmp_path / "openai.yaml")
+
+
+def test_absolute_name_ignores_cassette_library_dir(tmp_path: Path) -> None:
+    absolute = str(tmp_path / "openai.yaml")
+    assert Cassetter(cassette_library_dir="tests/cassettes").cassette(absolute).path == absolute
+
+
+def test_record_mode_accepts_string_and_enum() -> None:
+    assert Cassetter(record_mode="all").cassette("test.yaml").record_mode == RecordMode.ALL
+    assert Cassetter(record_mode=RecordMode.NEW_EPISODES).cassette("test.yaml").record_mode == RecordMode.NEW_EPISODES
+
+
+def test_on_expiry_is_honored(tmp_path: Path) -> None:
+    path = _make_cassette(str(tmp_path / "test.yaml"))
+    recorder = Cassetter(record_mode="none", max_age="1h", on_expiry="fail")
+    with pytest.raises(CassetteExpiredError):
+        recorder.cassette(path).load()
+
+
+@pytest.mark.anyio
+async def test_use_cassette_replays_from_library_dir(tmp_path: Path) -> None:
+    _make_cassette(str(tmp_path / "test.yaml"))
+    recorder = Cassetter(cassette_library_dir=tmp_path, record_mode="none")
+
+    with recorder.use_cassette("test.yaml") as cassette:
+        async with httpx.AsyncClient() as client:
+            response = await client.get("https://example.com/api")
+
+    assert response.status_code == 200
+    assert cassette.all_played
+
+
+@pytest.mark.anyio
+async def test_call_is_an_alias_for_use_cassette(tmp_path: Path) -> None:
+    _make_cassette(str(tmp_path / "test.yaml"))
+    recorder = Cassetter(cassette_library_dir=tmp_path, record_mode="none", intercept=["httpx"])
+
+    with recorder("test.yaml"):
+        async with httpx.AsyncClient() as client:
+            response = await client.get("https://example.com/api")
+
+    assert response.status_code == 200
+
+
+def test_overrides_apply_to_a_single_cassette(tmp_path: Path) -> None:
+    _make_cassette(str(tmp_path / "test.yaml"))
+    recorder = Cassetter(cassette_library_dir=tmp_path, record_mode="none")
+
+    with pytest.warns(CassetteExpiredWarning):
+        with recorder.use_cassette("test.yaml", max_age="1h"):
+            pass
+
+    assert recorder.max_age is None
+    with recorder.use_cassette("test.yaml"):
+        pass
+
+
+def test_unknown_override_is_rejected(tmp_path: Path) -> None:
+    recorder = Cassetter(cassette_library_dir=tmp_path)
+    with pytest.raises(TypeError):
+        with recorder.use_cassette("test.yaml", nonexistent=True):
+            pass  # pragma: no cover
+
+
+def test_configuration_is_immutable() -> None:
+    recorder = Cassetter(record_mode="none")
+    with pytest.raises(AttributeError):
+        recorder.record_mode = "all"  # type: ignore[misc]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,8 +34,9 @@ def test_defaults_match_use_cassette() -> None:
 
 
 def test_cassette_library_dir_is_joined() -> None:
-    cassette = Cassetter(cassette_library_dir="tests/cassettes").cassette("openai.yaml")
-    assert cassette.path == os.path.join("tests", "cassettes", "openai.yaml")
+    library_dir = os.path.join("tests", "cassettes")
+    cassette = Cassetter(cassette_library_dir=library_dir).cassette("openai.yaml")
+    assert cassette.path == os.path.join(library_dir, "openai.yaml")
 
 
 def test_cassette_library_dir_accepts_path_like(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,7 +105,7 @@ def test_unknown_override_is_rejected(tmp_path: Path) -> None:
             pass  # pragma: no cover
 
 
-def test_configuration_is_immutable() -> None:
+def test_configuration_is_frozen() -> None:
     recorder = Cassetter(record_mode="none")
     with pytest.raises(AttributeError):
         recorder.record_mode = "all"  # type: ignore[misc]

--- a/tests/test_config_marker.py
+++ b/tests/test_config_marker.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from cassetter import Cassetter
+from cassetter.cassette import Cassette
+
+RECORDER = Cassetter(
+    record_mode="none",
+    cassette_library_dir=Path(__file__).parent / "cassettes" / "test_config_marker",
+)
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> Cassetter:
+    return RECORDER
+
+
+@pytest.mark.vcr
+def test_vcr_config_accepts_a_cassetter(cassette: Cassette) -> None:
+    with httpx.Client() as client:
+        response = client.get("https://example.com/config-test")
+    assert response.status_code == 200
+    assert response.json() == {"config": True}
+
+
+def test_the_same_configuration_works_outside_pytest() -> None:
+    with RECORDER.use_cassette("test_vcr_config_accepts_a_cassetter.yaml"):
+        with httpx.Client() as client:
+            response = client.get("https://example.com/config-test")
+    assert response.json() == {"config": True}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,7 +6,8 @@ import pytest
 from cassetter._core import Body, Cassette as RustCassette, HttpInteraction, HttpRequest, HttpResponse
 from cassetter._state import acquire_patches, installed
 from cassetter.cassette import CassetteExpiredWarning
-from cassetter.context import _AUTO_DETECT_ORDER, _INTERCEPTOR_MAP, resolve_interceptors, use_cassette
+from cassetter.context import use_cassette
+from cassetter.intercept._registry import _AUTO_DETECT_ORDER, _INTERCEPTOR_MAP, resolve_interceptors
 from cassetter.recording import RecordMode
 
 pytest_plugins = ("anyio",)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from cassetter import Cassetter
 from cassetter._core import Body, Cassette as RustCassette, HttpInteraction, HttpRequest, HttpResponse
 from cassetter._types import CassetteConfig
 from cassetter.cassette import CassetteExpiredError, CassetteExpiredWarning
@@ -305,6 +306,106 @@ def test_resolve_cassette_filter_query_parameters(tmp_path: object) -> None:
     )
 
     assert cassette is not None
+
+
+def test_resolve_cassette_from_cassetter(tmp_path: object) -> None:
+    library_dir = os.path.join(str(tmp_path), "shared_cassettes")
+    os.makedirs(library_dir, exist_ok=True)
+    RustCassette().save(os.path.join(library_dir, "test_func.yaml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=Cassetter(cassette_library_dir=library_dir),
+        cli_record_mode=None,
+        test_fspath=os.path.join(str(tmp_path), "test_example.py"),
+        vcr_cassette_dir=os.path.join(str(tmp_path), "fixture_dir"),
+    )
+
+    assert cassette.path == os.path.join(library_dir, "test_func.yaml")
+
+
+def test_resolve_cassette_from_cassetter_defaults_to_none_record_mode(tmp_path: object) -> None:
+    """An unset record mode means `none` under pytest, even though `use_cassette` defaults to `once`."""
+    cassette_dir = os.path.join(str(tmp_path), "cassettes")
+    os.makedirs(cassette_dir, exist_ok=True)
+    RustCassette().save(os.path.join(cassette_dir, "test_func.yaml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=Cassetter(),
+        cli_record_mode=None,
+        test_fspath=os.path.join(str(tmp_path), "test_example.py"),
+        vcr_cassette_dir=cassette_dir,
+    )
+
+    assert cassette.record_mode == RecordMode.NONE
+
+
+def test_resolve_cassette_marker_dir_overrides_cassette_library_dir(tmp_path: object) -> None:
+    marker_dir = os.path.join(str(tmp_path), "marker_dir", "test_example")
+    os.makedirs(marker_dir, exist_ok=True)
+    RustCassette().save(os.path.join(marker_dir, "test_func.yaml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={"cassette_dir": "marker_dir"},
+        vcr_config=Cassetter(cassette_library_dir=os.path.join(str(tmp_path), "shared")),
+        cli_record_mode=None,
+        test_fspath=os.path.join(str(tmp_path), "test_example.py"),
+    )
+
+    assert cassette.path == os.path.join(marker_dir, "test_func.yaml")
+
+
+def test_resolve_cassette_ini_on_expiry(tmp_path: object) -> None:
+    cassette_dir = os.path.join(str(tmp_path), "cassettes")
+    os.makedirs(cassette_dir, exist_ok=True)
+    path = os.path.join(cassette_dir, "test_func.yaml")
+    c = RustCassette()
+    c.add_interaction(
+        HttpInteraction(
+            request=HttpRequest("GET", "https://example.com/"),
+            response=HttpResponse(200, body=Body("text", "ok")),
+            recorded_at="2020-01-01T00:00:00Z",
+        )
+    )
+    c.save(path)
+
+    with pytest.raises(CassetteExpiredError):
+        _resolve_cassette(
+            node_name="test_func",
+            marker_args=(),
+            marker_kwargs={},
+            vcr_config=Cassetter(max_age="1d"),
+            cli_record_mode=None,
+            test_fspath=os.path.join(str(tmp_path), "test_example.py"),
+            vcr_cassette_dir=cassette_dir,
+            ini_on_expiry="fail",
+        )
+
+
+def test_resolve_cassette_ignores_unknown_vcr_config_keys(tmp_path: object) -> None:
+    """Keys VCR.py supports but cassetter handles automatically are no-ops, not errors."""
+    cassette_dir = os.path.join(str(tmp_path), "cassettes")
+    os.makedirs(cassette_dir, exist_ok=True)
+    RustCassette().save(os.path.join(cassette_dir, "test_func.yaml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config={"record_mode": "none", "decode_compressed_response": True},  # type: ignore[typeddict-unknown-key]
+        cli_record_mode=None,
+        test_fspath=os.path.join(str(tmp_path), "test_example.py"),
+        vcr_cassette_dir=cassette_dir,
+    )
+
+    assert cassette.record_mode == RecordMode.NONE
 
 
 def test_ini_options_registered() -> None:

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,6 +14,7 @@ nav = [
     { "Tutorial" = [
         { "Use it with pytest" = "tutorial/pytest.md" },
         { "Use the context manager" = "tutorial/context-manager.md" },
+        { "Reuse a configuration" = "tutorial/configuration.md" },
         { "Record modes" = "tutorial/record-modes.md" },
         { "Request matching" = "tutorial/matching.md" },
         { "Safe by default" = "tutorial/security.md" },


### PR DESCRIPTION
Closes #25.

Options shared by a group of cassettes can be declared once instead of on every `use_cassette()` call:

```python
from cassetter import Cassetter

recorder = Cassetter(
    cassette_library_dir="tests/cassettes",
    record_mode="none",
    filter_headers=["x-gateway-apikey"],
    before_record_request=_request_hook,
)

with recorder.use_cassette("openai.yaml"):
    ...

# override any option for a single cassette
with recorder.use_cassette("openai.yaml", record_mode="all"):
    ...
```

`Cassetter` takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against (absolute names win). It is frozen and callable, so `recorder("openai.yaml")` works and no test can mutate a configuration shared with another.

The `vcr_config` fixture accepts one as well as the existing dict, so a single object configures both a pytest suite and direct `use_cassette()` calls:

```python
@pytest.fixture(scope="module")
def vcr_config() -> Cassetter:
    return recorder
```

## Two decisions worth a look

- `record_mode` and `on_expiry` are stored as unset rather than as real defaults. The pytest plugin defaults to `none` for safety, and a `Cassetter` returned from `vcr_config` that silently flipped a suite to `once` would defeat that.
- Under pytest, `cassette_library_dir` (when set) replaces the `vcr_cassette_dir` fixture. That fixture always supplies a value, so the option would be dead otherwise. A `cassette_dir` on the marker still wins.

One behaviour narrowed: `use_cassette()` is no longer a `@contextlib.contextmanager` generator, so `@use_cassette("x.yaml")` as a decorator still works at runtime but no longer type-checks. That form was never documented or tested.

## Refactor that came with it

Both entry points now build cassettes through `Cassetter`, which removes the option plumbing duplicated between `context.py` and the pytest plugin. `resolve_interceptors` moves to `intercept/_registry.py` (verbatim) to break the resulting import cycle.

## Checks

521 tests pass, coverage stays at 100%, `ruff` and `mypy --strict` on `src/` are clean. Design rationale and rejected alternatives are in `SPECIFICATION.md` section 7; docs in `docs/tutorial/configuration.md`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.