### PR TITLE
Declare project URLs so PyPI links to the docs and repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = []
 
 [project.urls]
 Homepage = "https://kludex.github.io/cassetter/"
-Documentation = "https://kludex.github.io/cassetter/"
 Repository = "https://github.com/Kludex/cassetter"
 Issues = "https://github.com/Kludex/cassetter/issues"
 Changelog = "https://github.com/Kludex/cassetter/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,13 @@ classifiers = [
 ]
 dependencies = []
 
+[project.urls]
+Homepage = "https://kludex.github.io/cassetter/"
+Documentation = "https://kludex.github.io/cassetter/"
+Repository = "https://github.com/Kludex/cassetter"
+Issues = "https://github.com/Kludex/cassetter/issues"
+Changelog = "https://github.com/Kludex/cassetter/releases"
+
 [project.optional-dependencies]
 httpx = ["httpx>=0.24"]
 aiohttp = ["aiohttp>=3.9"]


### PR DESCRIPTION
`cassetter` publishes no `project_urls` at all - `https://pypi.org/pypi/cassetter/json` returns `"project_urls": null` and `"home_page": null`, so the PyPI sidebar has no link to the documentation site, the repository, the issue tracker, or the release notes.

```toml
[project.urls]
Homepage = "https://kludex.github.io/cassetter/"
Repository = "https://github.com/Kludex/cassetter"
Issues = "https://github.com/Kludex/cassetter/issues"
Changelog = "https://github.com/Kludex/cassetter/releases"
```

`Changelog` points at GitHub Releases because there is no `CHANGELOG` file and the releases already carry the notes.

All four labels are ones PyPI recognises, so each renders with its own icon in the sidebar rather than being lumped under "Extra".

## Verification

Built both artifacts and read the metadata back, rather than assuming maturin forwards the table:

```
$ uv run maturin build
Project-URL: Changelog, https://github.com/Kludex/cassetter/releases
Project-URL: Homepage, https://kludex.github.io/cassetter/
Project-URL: Issues, https://github.com/Kludex/cassetter/issues
Project-URL: Repository, https://github.com/Kludex/cassetter
```

The sdist's `PKG-INFO` carries the same four. Every URL returns 200.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
