### PR TITLE
Build the free-threaded wheel in its own maturin pass

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,7 @@ jobs:
       - if: matrix.os != 'ubuntu-latest'
         uses: actions/setup-python@v5
         with:
-          # Each version is prepended to PATH in turn, so the last one listed
-          # owns the plain `python3.X` name. The free-threaded install ships a
-          # `python3.14` of its own, so it goes first or it shadows the GIL
-          # build and 3.14t gets packaged twice under both tags.
           python-version: |
-            3.14t
             3.10
             3.11
             3.12
@@ -61,11 +56,23 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          # Free-threaded CPython uses its own ABI tag (cp314t), so a normal
-          # cp314 wheel will not install there and the module declares
-          # gil_used = false. 3.13t is not shipped: PyO3 refuses to build for
-          # the free-threaded build of CPython below 3.14.
-          args: --release --out dist --manifest-path rust/Cargo.toml --interpreter python3.10 python3.11 python3.12 python3.13 python3.14 python3.14t
+          args: --release --out dist --manifest-path rust/Cargo.toml --interpreter python3.10 python3.11 python3.12 python3.13 python3.14
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+      # Free-threaded CPython uses its own ABI tag, so a cp314 wheel will not
+      # install there and the module declares gil_used = false. It is installed
+      # only now because a free-threaded 3.14 answers to `python3.14` as well,
+      # and maturin picks it over the GIL build - on Windows whatever the PATH
+      # order - which would leave the release with no cp314 wheel. 3.13t is not
+      # shipped at all: PyO3 refuses the free-threaded build below 3.14.
+      - if: matrix.os != 'ubuntu-latest'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14t"
+          allow-prereleases: true
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --manifest-path rust/Cargo.toml --interpreter python3.14t
           manylinux: ${{ matrix.manylinux || 'auto' }}
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Follow-up to [#69](https://github.com/Kludex/cassetter/pull/69), which merged with only its first commit. The ordering approach it landed is not enough, and v0.7.0 shipped without `cassetter-0.7.0-cp314-cp314-win_amd64.whl` as a result - Windows users on GIL-enabled 3.14 fall back to the sdist, which 0.6.0 did not require.

maturin resolves `python3.14` to the free-threaded build whenever one is present, and on Windows it does so whatever the PATH order - the [release run](https://github.com/Kludex/cassetter/actions/runs/30827005906) logs `CPython 3.14t at C:\hostedtoolcache\windows\Python\3.14.6\x64-freethreaded\python.exe` for the plain `python3.14` name. Free-threaded 3.14 is now installed only after the GIL wheels are built and gets its own maturin pass, so each pass sees only the interpreters it builds for.

Already verified: the [smoke run of this exact change](https://github.com/Kludex/cassetter/actions/runs/30821933204) is green on all seven legs, each producing 3.10, 3.11, 3.12, 3.13, 3.14 and 3.14t - Windows included.

0.7.0 is immutable, so the missing wheel needs either a 0.7.1 or a one-off upload of that single file to 0.7.0.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.