### PR TITLE
Preserve JSON key order in recorded bodies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -500,6 +500,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,9 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.29" }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `preserve_order` keeps a recorded JSON body in the order the server sent it, so a
+# cassette stays a faithful recording rather than an alphabetized rewrite of one.
+serde_json = { version = "1", features = ["preserve_order"] }
 serde-saphyr = "0.0.29"
 flate2 = "1"
 brotli = { version = "8", default-features = false, features = ["std"] }

--- a/rust/src/security/body.rs
+++ b/rust/src/security/body.rs
@@ -55,27 +55,41 @@ impl Scrubber {
         value: &serde_json::Value,
         replacement: &str,
     ) -> serde_json::Value {
+        let mut scrubbed = value.clone();
+        self.scrub_json_in_place(&mut scrubbed, replacement);
+        scrubbed
+    }
+
+    /// Scrub a parsed tree in place, reporting whether anything was replaced.
+    ///
+    /// A caller that owns its tree walks it once instead of rebuilding it into a
+    /// fresh map and deep-comparing the two, which is the difference between one
+    /// allocation per object and three on a streaming body with a `data:` payload
+    /// per chunk.
+    fn scrub_json_in_place(&self, value: &mut serde_json::Value, replacement: &str) -> bool {
         match value {
             serde_json::Value::Object(map) => {
-                let mut new_map = serde_json::Map::new();
-                for (key, val) in map {
-                    if self.matches_key(key) {
-                        new_map.insert(
-                            key.clone(),
-                            serde_json::Value::String(replacement.to_string()),
-                        );
-                    } else {
-                        new_map.insert(key.clone(), self.scrub_json_value(val, replacement));
+                let mut scrubbed = false;
+                for (key, val) in map.iter_mut() {
+                    if !self.matches_key(key) {
+                        scrubbed |= self.scrub_json_in_place(val, replacement);
+                    } else if val.as_str() != Some(replacement) {
+                        // A value already holding the replacement is left alone, so a
+                        // re-scrub reports no change and the body is not reformatted.
+                        *val = serde_json::Value::String(replacement.to_string());
+                        scrubbed = true;
                     }
                 }
-                serde_json::Value::Object(new_map)
+                scrubbed
             }
-            serde_json::Value::Array(arr) => serde_json::Value::Array(
-                arr.iter()
-                    .map(|v| self.scrub_json_value(v, replacement))
-                    .collect(),
-            ),
-            _ => value.clone(),
+            serde_json::Value::Array(arr) => {
+                let mut scrubbed = false;
+                for val in arr.iter_mut() {
+                    scrubbed |= self.scrub_json_in_place(val, replacement);
+                }
+                scrubbed
+            }
+            _ => false,
         }
     }
 
@@ -101,12 +115,11 @@ impl Scrubber {
     /// unchanged when nothing matched, so bodies without secrets are never
     /// reformatted.
     fn scrub_json_text(&self, text: &str, replacement: &str) -> Option<String> {
-        let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
-        let scrubbed = self.scrub_json_value(&parsed, replacement);
-        if scrubbed == parsed {
+        let mut parsed: serde_json::Value = serde_json::from_str(text).ok()?;
+        if !self.scrub_json_in_place(&mut parsed, replacement) {
             return Some(text.to_string());
         }
-        serde_json::to_string(&scrubbed).ok()
+        serde_json::to_string(&parsed).ok()
     }
 
     /// Scrub `data:` payloads of a Server-Sent Events stream.

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import stat
@@ -21,6 +22,7 @@ from cassetter._core import (
     MatchConfig,
     SecurityConfig,
     WsInteraction,
+    process_body,
     scrub_interaction,
 )
 from cassetter.cassette import (
@@ -100,6 +102,32 @@ def test_rust_cassette_save_and_load(tmp_path: object) -> None:
     assert len(c2) == 1
     assert c2.interactions[0].request.method == "POST"
     assert c2.interactions[0].response.status == 200
+
+
+def test_rust_cassette_preserves_json_key_order(tmp_path: object) -> None:
+    path = os.path.join(str(tmp_path), "key-order.yaml")
+    raw = b'{"id":"chatcmpl-abc","choices":[],"created":1,"usage":{"total_tokens":3,"prompt_tokens":1}}'
+
+    c = RustCassette()
+    c.add_interaction(
+        HttpInteraction(
+            request=HttpRequest("POST", "https://api.example.com/chat", {}, Body("none")),
+            response=HttpResponse(
+                200,
+                {"content-type": ["application/json"]},
+                process_body(raw, "application/json"),
+            ),
+            recorded_at="2026-02-20T10:30:01Z",
+        )
+    )
+    c.save(path)
+
+    with open(path) as f:
+        content = f.read()
+    assert content.index("id: chatcmpl-abc") < content.index("choices: []")
+
+    replayed = RustCassette.load(path).interactions[0].response.body.content
+    assert json.dumps(replayed, separators=(",", ":")).encode() == raw
 
 
 def test_rust_cassette_load_nonexistent() -> None:


### PR DESCRIPTION
`serde_json` was built without `preserve_order`, so a JSON body went through a `BTreeMap` and came back alphabetized. A cassette then replayed a byte order no server ever sent:

```
server sent:  {"id":"chatcmpl-abc","choices":[],"created":1,"usage":{"total_tokens":3,"prompt_tokens":1}}
cassette gave: {"choices":[],"created":1,"id":"chatcmpl-abc","usage":{"prompt_tokens":1,"total_tokens":3}}
```

That matters wherever the response body is asserted on verbatim rather than parsed. It surfaced migrating a service off vcrpy: seven snapshot tests pinning a recorded body started failing, purely from the reordering.

Enabling `preserve_order` switches `serde_json::Value` to an `IndexMap`, which the YAML serializer then writes in wire order and the parser reads back in document order. `Map` equality stays order-independent under `IndexMap`, so `json_body` matching is unaffected.

Added a round-trip regression test asserting the recorded bytes come back identical; it fails without the feature.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.