### PR TITLE
Group dependabot updates and add a one-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,31 @@ updates:
     directory: /rust
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      uv:
+        patterns:
+          - "*"


### PR DESCRIPTION
Each ecosystem (cargo, github-actions, uv) now opens a single grouped PR instead of one per dependency, and `cooldown.default-days: 7` makes dependabot wait a week after a release before proposing it.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.