### PR TITLE
Let setup-uv provide the interpreter instead of setup-python

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - run: uv sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - run: uv sync
@@ -71,10 +70,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - run: uv sync
       - run: uv run maturin develop --release
       - run: uv run coverage run -m pytest tests/ --strict-config --strict-markers -v

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - run: uv sync --only-group docs

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - run: rm uv.lock


### PR DESCRIPTION
`astral-sh/setup-uv` takes a `python-version` input (it sets `UV_PYTHON`), so `actions/setup-python` was doing nothing that uv doesn't already do in `ci.yml`, `docs.yml`, `benchmarks.yml` and `latest-deps.yml`. The version moves onto `setup-uv` rather than being dropped: `requires-python` is `>=3.10` and there is no `.python-version`, so an unpinned `uv sync` would pick an arbitrary interpreter and silently collapse the test matrix.

`allow-prereleases` goes away with it - uv installs prereleases by name when asked, and 3.14 is stable anyway.

`publish.yml` keeps `setup-python`: it has no uv, and `maturin-action` needs the interpreters installed on macOS and Windows.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated benchmark, CI, documentation, and dependency workflows.
  * Consolidated Python version configuration through the existing environment setup process.
  * Removed redundant Python installation steps while preserving workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->