### PR TITLE
Borrow the YAML source when it holds no binary scalars

### DIFF
--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
 use base64::Engine;
@@ -159,9 +160,11 @@ fn opens_block_scalar(trimmed: &str) -> bool {
 /// Any other block scalar is copied through verbatim without inspecting its
 /// content, because a recorded body can legitimately contain a line ending in
 /// `!!binary |` and scanning into it would replace that line with a sentinel.
-pub fn extract_binary_scalars(content: &str) -> (String, Vec<Vec<u8>>) {
+pub fn extract_binary_scalars(content: &str) -> (Cow<'_, str>, Vec<Vec<u8>>) {
     if !content.contains("!!binary") {
-        return (content.to_string(), Vec::new());
+        // Borrow rather than copy: a cassette dominated by large bodies is
+        // mostly bytes this rewrite never touches.
+        return (Cow::Borrowed(content), Vec::new());
     }
     let mut out: Vec<String> = Vec::new();
     let mut binaries: Vec<Vec<u8>> = Vec::new();
@@ -226,7 +229,7 @@ pub fn extract_binary_scalars(content: &str) -> (String, Vec<Vec<u8>>) {
         out.push(line.to_string());
         i += 1;
     }
-    (out.join("\n"), binaries)
+    (Cow::Owned(out.join("\n")), binaries)
 }
 
 /// Deserialize status from either a plain integer (cassetter) or `{code: N, message: "..."}` (VCR).

--- a/rust/src/cassette/format.rs
+++ b/rust/src/cassette/format.rs
@@ -1034,6 +1034,17 @@ interactions:
         assert!(binaries.is_empty());
     }
 
+    /// The prose case above still holds a `!!binary` marker, so it rewrites.
+    /// Only a cassette with no marker at all reaches the borrow.
+    #[test]
+    fn test_extract_binary_scalars_borrows_yaml_without_marker() {
+        let yaml = "body:\n  string: |\n    plain prose\n";
+        let (content, binaries) = extract_binary_scalars(yaml);
+        assert!(matches!(content, Cow::Borrowed(_)), "{content:?}");
+        assert_eq!(content, yaml);
+        assert!(binaries.is_empty());
+    }
+
     #[test]
     fn test_round_trip_preserves_newline_only_strings() {
         // serde-saphyr auto-selects block scalars for newline-only strings,


### PR DESCRIPTION
`extract_binary_scalars` copied the whole file into a fresh `String` before handing it to the parser, even when it had nothing to rewrite. A cassette with no `!!binary` scalar - the common case - paid a full-file allocation and copy for a pass that returned its input unchanged.

Returning `Cow` lets that case borrow instead. The caller in `load_impl` shadows its `content` binding, so the original `String` stays alive for the borrow.

## Benchmark

Loading a cassette built from JSON bodies with no `!!binary` scalars, best of 15:

| cassette | before | after |
|---|---|---|
| 0.9 MB | 8.728 ms | 8.659 ms |
| 3.7 MB | 35.395 ms | 35.165 ms |
| 9.3 MB | 88.994 ms | 87.894 ms |

About 1%. The copy was never the bulk of a load - the YAML parse is - so this is worth taking for the allocation it removes rather than for the clock.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cassette processing efficiency by avoiding unnecessary data copying when content contains no binary values.
  * Reduced memory usage and processing overhead for unchanged cassette content.
  * Binary value extraction continues to work as expected when binary markers are present.
  * No changes are required to existing cassette files or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->