### PR TITLE
Support the `rewrite` record mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ def vcr_config() -> Cassetter:
 | `once` | Record if cassette doesn't exist. Replay if it does. |
 | `new_episodes` | Replay existing interactions. Record new ones. |
 | `all` | Record everything, overwriting the cassette. |
+| `rewrite` | Delete the cassette, then record everything. |
 
 Set via CLI: `pytest --record-mode=none`
 

--- a/docs/tutorial/record-modes.md
+++ b/docs/tutorial/record-modes.md
@@ -8,6 +8,7 @@ The record mode controls what happens when a request is made under an active cas
 | `once` | Record if the cassette doesn't exist. Replay if it does. |
 | `new_episodes` | Replay existing interactions. Record new ones. |
 | `all` | Record everything, overwriting the cassette. |
+| `rewrite` | Delete the cassette, then record everything. |
 
 ## `none`
 
@@ -44,6 +45,15 @@ Use it to re-record a cassette from scratch, for example after an API change.
 
 ```python
 with use_cassette("cassette.yaml", record_mode="all"):
+    ...
+```
+
+## `rewrite`
+
+Same as `all`, except the cassette file is deleted before the test runs. A test that no longer makes the request it used to leaves no cassette behind, instead of leaving an empty one.
+
+```python
+with use_cassette("cassette.yaml", record_mode="rewrite"):
     ...
 ```
 

--- a/src/cassetter/cassette.py
+++ b/src/cassetter/cassette.py
@@ -33,6 +33,9 @@ from cassetter.intercept._base import is_localhost
 from cassetter.introspection import RecordedRequest, recorded_request
 from cassetter.recording import RecordMode
 
+_DISCARDING_MODES = (RecordMode.ALL, RecordMode.REWRITE)
+"""Modes that start from an empty cassette instead of replaying what is on disk."""
+
 
 class CassetteNotFoundError(Exception):
     """Raised when a cassette file is not found and record mode doesn't allow recording."""
@@ -218,12 +221,18 @@ class Cassette:
         """Load the cassette from disk, or create a new one based on record mode."""
         exists = os.path.exists(self._path)
 
-        if self._record_mode == RecordMode.ALL or not exists:
+        # `rewrite` drops the file before recording, so a run that captures
+        # nothing leaves no stale cassette behind.
+        if self._record_mode == RecordMode.REWRITE and exists:
+            os.remove(self._path)
+            exists = False
+
+        if self._record_mode in _DISCARDING_MODES or not exists:
             self._inner = _RustCassette()
             self._record_orders = []
             self._next_record_order = 0
             self._rebuild_match_inner()
-            if self._record_mode == RecordMode.ALL:
+            if self._record_mode in _DISCARDING_MODES:
                 self._dirty = True
             return
 
@@ -328,7 +337,7 @@ class Cassette:
 
     @property
     def can_record(self) -> bool:
-        if self._record_mode in (RecordMode.ALL, RecordMode.NEW_EPISODES):
+        if self._record_mode in (RecordMode.ALL, RecordMode.NEW_EPISODES, RecordMode.REWRITE):
             return True
         # `once` records only when the cassette didn't exist: with an existing
         # cassette an unmatched request must raise instead of silently hitting

--- a/src/cassetter/pytest_plugin/orphans.py
+++ b/src/cassetter/pytest_plugin/orphans.py
@@ -42,8 +42,8 @@ def add_options(parser: pytest.Parser) -> None:
         "--record-mode",
         action="store",
         default=None,
-        choices=["none", "new_episodes", "all", "once"],
-        help="VCR record mode: none, new_episodes, all, once",
+        choices=["none", "new_episodes", "all", "once", "rewrite"],
+        help="VCR record mode: none, new_episodes, all, once, rewrite",
     )
     group.addoption(
         "--vcr-check-orphans",

--- a/src/cassetter/recording.py
+++ b/src/cassetter/recording.py
@@ -18,6 +18,9 @@ class RecordMode(enum.Enum):
     ONCE = enum.auto()
     """Record if cassette doesn't exist. Replay if it does."""
 
+    REWRITE = enum.auto()
+    """Delete the cassette up front, then record everything. A run that records nothing leaves no file."""
+
     @classmethod
     def from_str(cls, value: str) -> RecordMode:
         mapping = {
@@ -25,6 +28,7 @@ class RecordMode(enum.Enum):
             "new_episodes": cls.NEW_EPISODES,
             "all": cls.ALL,
             "once": cls.ONCE,
+            "rewrite": cls.REWRITE,
         }
         normalized = value.lower().replace("-", "_")
         if normalized not in mapping:

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -6,6 +6,7 @@ import re
 import stat
 import sys
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 import yaml
@@ -153,6 +154,7 @@ def test_cassette_interactions_before_load() -> None:
 def test_cassette_can_record() -> None:
     assert Cassette("/tmp/t.yaml", record_mode=RecordMode.ALL).can_record is True
     assert Cassette("/tmp/t.yaml", record_mode=RecordMode.NEW_EPISODES).can_record is True
+    assert Cassette("/tmp/t.yaml", record_mode=RecordMode.REWRITE).can_record is True
     assert Cassette("/tmp/t.yaml", record_mode=RecordMode.ONCE).can_record is True
     assert Cassette("/tmp/t.yaml", record_mode=RecordMode.NONE).can_record is False
 
@@ -301,6 +303,7 @@ def test_record_mode_from_str() -> None:
     assert RecordMode.from_str("once") == RecordMode.ONCE
     assert RecordMode.from_str("new_episodes") == RecordMode.NEW_EPISODES
     assert RecordMode.from_str("new-episodes") == RecordMode.NEW_EPISODES
+    assert RecordMode.from_str("rewrite") == RecordMode.REWRITE
 
 
 def test_record_mode_from_str_invalid() -> None:
@@ -977,6 +980,50 @@ def test_all_mode_truncates_stale_cassette(tmp_path: object) -> None:
     rerecord.load()
     rerecord.save()
     assert len(RustCassette.load(path)) == 0
+
+
+def test_rewrite_mode_discards_recorded_interactions(tmp_path: Path) -> None:
+    path = str(tmp_path / "stale.yaml")
+    _save_interaction(path, "GET", "https://example.com/old", "old")
+    assert len(RustCassette.load(path)) == 1
+
+    rewrite = Cassette(path, record_mode=RecordMode.REWRITE)
+    rewrite.load()
+    assert rewrite.interactions == []
+    assert rewrite.can_record is True
+    rewrite.record(
+        method="GET",
+        uri="https://example.com/new",
+        request_headers={},
+        request_body=None,
+        status=200,
+        response_headers={},
+        response_body=b"{}",
+    )
+    rewrite.save()
+
+    written = RustCassette.load(path)
+    assert [i.request.uri for i in written.interactions] == ["https://example.com/new"]
+
+
+def test_rewrite_mode_leaves_no_file_when_nothing_is_recorded(tmp_path: Path) -> None:
+    """Unlike `all`, which truncates, `rewrite` removes the cassette up front."""
+    path = str(tmp_path / "stale.yaml")
+    _save_interaction(path, "GET", "https://example.com/old", "old")
+
+    rewrite = Cassette(path, record_mode=RecordMode.REWRITE)
+    rewrite.load()
+    rewrite.save()
+    assert not os.path.exists(path)
+
+
+def test_rewrite_mode_without_existing_cassette(tmp_path: Path) -> None:
+    path = str(tmp_path / "missing.yaml")
+    cassette = Cassette(path, record_mode=RecordMode.REWRITE)
+    cassette.load()
+    assert cassette.interactions == []
+    cassette.save()
+    assert not os.path.exists(path)
 
 
 def test_save_preserves_file_permissions(tmp_path: object) -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -125,6 +125,27 @@ def test_resolve_cassette_default_config(tmp_path: object) -> None:
     assert len(interceptor_classes) >= 1
 
 
+def test_resolve_cassette_cli_rewrite_drops_the_cassette(tmp_path: Path) -> None:
+    """`--record-mode=rewrite` removes the file at load, so a stale one cannot replay."""
+    test_dir = str(tmp_path)
+    cassette_dir = tmp_path / "cassettes" / "test_example"
+    cassette_dir.mkdir(parents=True)
+    yaml_path = cassette_dir / "test_func.yaml"
+    RustCassette().save(str(yaml_path))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=CassetteConfig(record_mode="none", cassette_dir="cassettes"),
+        cli_record_mode="rewrite",
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+    )
+
+    assert cassette.record_mode == RecordMode.REWRITE
+    assert not yaml_path.exists()
+
+
 def test_resolve_cassette_custom_cassette_name(tmp_path: object) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")


### PR DESCRIPTION
`rewrite` is pytest-recording's fifth record mode: it deletes the cassette file up front and then records everything. That differs from `all` in one visible way - a test that no longer makes the request it used to leaves no cassette behind, instead of an empty one.

pydantic-ai drives its live re-recording with it (`--record-mode=rewrite`, and `vcr_config` returning `{'record_mode': 'rewrite'}` in `tests/models/test_model_names.py`), so without it that test errors at setup with `unknown record mode: 'rewrite'`.

Verified against pydantic-ai's suite: the test now gets past cassette setup.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `rewrite` recording mode that replaces existing cassette interactions with newly recorded ones.
  * Empty recordings leave no cassette file behind.
  * The command-line recording option now supports `rewrite`.

* **Documentation**
  * Added documentation explaining `rewrite` mode and how it differs from `all`.

* **Tests**
  * Added coverage for replacing, creating, and removing cassettes in rewrite mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->