### PR TITLE
Annotate `tmp_path` fixtures as `Path`

### DIFF
--- a/tests/test_before_record_response.py
+++ b/tests/test_before_record_response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import httpx
 import pytest
@@ -13,7 +14,7 @@ pytest_plugins = ("anyio",)
 
 
 @pytest.fixture
-def cassette_path(tmp_path: object) -> str:
+def cassette_path(tmp_path: Path) -> str:
     return os.path.join(str(tmp_path), "response_hook.yaml")
 
 
@@ -71,7 +72,7 @@ async def test_before_record_response_modifies_status(cassette_path: str) -> Non
 
 
 @pytest.mark.anyio
-async def test_before_record_response_not_called_on_replay(tmp_path: object) -> None:
+async def test_before_record_response_not_called_on_replay(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "replay.yaml")
     c = RustCassette()
     c.add_interaction(
@@ -96,7 +97,7 @@ async def test_before_record_response_not_called_on_replay(tmp_path: object) -> 
     assert calls == []
 
 
-def test_before_record_response_with_vcr_config(tmp_path: object) -> None:
+def test_before_record_response_with_vcr_config(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
 
     def my_hook(response: RawResponse) -> RawResponse:
@@ -106,7 +107,7 @@ def test_before_record_response_with_vcr_config(tmp_path: object) -> None:
     assert cassette.before_record_response is my_hook
 
 
-def test_before_record_response_default_is_none(tmp_path: object) -> None:
+def test_before_record_response_default_is_none(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     cassette = Cassette(path)
     assert cassette.before_record_response is None

--- a/tests/test_bypass.py
+++ b/tests/test_bypass.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import httpx
 import pytest
@@ -13,7 +14,7 @@ pytest_plugins = ("anyio",)
 
 
 @pytest.fixture
-def cassette_path(tmp_path: object) -> str:
+def cassette_path(tmp_path: Path) -> str:
     return os.path.join(str(tmp_path), "bypass.yaml")
 
 

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -68,7 +68,7 @@ def test_rust_cassette_mark_played() -> None:
     assert c.unplayed_count == 0
 
 
-def test_rust_cassette_save_and_load(tmp_path: object) -> None:
+def test_rust_cassette_save_and_load(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
 
     c = RustCassette()
@@ -105,7 +105,7 @@ def test_rust_cassette_save_and_load(tmp_path: object) -> None:
     assert c2.interactions[0].response.status == 200
 
 
-def test_rust_cassette_preserves_json_key_order(tmp_path: object) -> None:
+def test_rust_cassette_preserves_json_key_order(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "key-order.yaml")
     raw = b'{"id":"chatcmpl-abc","choices":[],"created":1,"usage":{"total_tokens":3,"prompt_tokens":1}}'
 
@@ -180,7 +180,7 @@ def test_cassette_record_before_load() -> None:
     assert len(cassette.interactions) == 1
 
 
-def test_cassette_load_existing_file(tmp_path: object) -> None:
+def test_cassette_load_existing_file(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "existing.yaml")
     c = RustCassette()
     c.add_interaction(
@@ -204,14 +204,14 @@ def test_record_mode_none_missing_file() -> None:
     assert cassette.interactions == []
 
 
-def test_record_mode_once_creates_new(tmp_path: object) -> None:
+def test_record_mode_once_creates_new(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "new.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ONCE)
     cassette.load()
     assert cassette.interactions == []
 
 
-def test_cassette_record_and_play(tmp_path: object) -> None:
+def test_cassette_record_and_play(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -237,7 +237,7 @@ def test_cassette_record_and_play(tmp_path: object) -> None:
     assert response.status == 200
 
 
-def test_cassette_play_no_match(tmp_path: object) -> None:
+def test_cassette_play_no_match(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
     # Create empty cassette file
@@ -248,7 +248,7 @@ def test_cassette_play_no_match(tmp_path: object) -> None:
         cassette.play("GET", "https://nonexistent.com/", {}, None)
 
 
-def test_cassette_save_persists(tmp_path: object) -> None:
+def test_cassette_save_persists(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "persist.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -270,7 +270,7 @@ def test_cassette_save_persists(tmp_path: object) -> None:
     assert len(cassette2.interactions) == 1
 
 
-def test_cassette_security_filtering_on_record(tmp_path: object) -> None:
+def test_cassette_security_filtering_on_record(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "secure.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -351,7 +351,7 @@ def _make_old_cassette(path: str, recorded_at: str) -> None:
     c.save(path)
 
 
-def test_expiry_no_expiry_when_max_age_none(tmp_path: object) -> None:
+def test_expiry_no_expiry_when_max_age_none(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2020-01-01T00:00:00Z")
 
@@ -360,7 +360,7 @@ def test_expiry_no_expiry_when_max_age_none(tmp_path: object) -> None:
     assert len(cassette.interactions) == 1
 
 
-def test_expiry_not_expired(tmp_path: object) -> None:
+def test_expiry_not_expired(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2099-01-01T00:00:00Z")
 
@@ -369,7 +369,7 @@ def test_expiry_not_expired(tmp_path: object) -> None:
     assert len(cassette.interactions) == 1
 
 
-def test_expiry_warn_on_expiry(tmp_path: object) -> None:
+def test_expiry_warn_on_expiry(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2020-01-01T00:00:00Z")
 
@@ -379,7 +379,7 @@ def test_expiry_warn_on_expiry(tmp_path: object) -> None:
     assert len(cassette.interactions) == 1
 
 
-def test_expiry_fail_on_expiry(tmp_path: object) -> None:
+def test_expiry_fail_on_expiry(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2020-01-01T00:00:00Z")
 
@@ -388,7 +388,7 @@ def test_expiry_fail_on_expiry(tmp_path: object) -> None:
         cassette.load()
 
 
-def test_expiry_rerecord_on_expiry(tmp_path: object) -> None:
+def test_expiry_rerecord_on_expiry(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2020-01-01T00:00:00Z")
 
@@ -397,7 +397,7 @@ def test_expiry_rerecord_on_expiry(tmp_path: object) -> None:
     assert len(cassette.interactions) == 0
 
 
-def test_expiry_empty_cassette_not_expired(tmp_path: object) -> None:
+def test_expiry_empty_cassette_not_expired(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     RustCassette().save(path)
 
@@ -406,7 +406,7 @@ def test_expiry_empty_cassette_not_expired(tmp_path: object) -> None:
     assert len(cassette.interactions) == 0
 
 
-def test_expiry_no_check_when_record_mode_all(tmp_path: object) -> None:
+def test_expiry_no_check_when_record_mode_all(tmp_path: Path) -> None:
     """RecordMode.ALL creates a fresh cassette, so expiry check never runs."""
     path = os.path.join(str(tmp_path), "test.yaml")
     _make_old_cassette(path, "2020-01-01T00:00:00Z")
@@ -416,7 +416,7 @@ def test_expiry_no_check_when_record_mode_all(tmp_path: object) -> None:
     assert len(cassette.interactions) == 0
 
 
-def test_expiry_no_check_when_file_missing(tmp_path: object) -> None:
+def test_expiry_no_check_when_file_missing(tmp_path: Path) -> None:
     """Missing file creates empty cassette, no expiry check."""
     path = os.path.join(str(tmp_path), "missing.yaml")
 
@@ -425,7 +425,7 @@ def test_expiry_no_check_when_file_missing(tmp_path: object) -> None:
     assert len(cassette.interactions) == 0
 
 
-def test_expiry_uses_newest_across_interaction_types(tmp_path: object) -> None:
+def test_expiry_uses_newest_across_interaction_types(tmp_path: Path) -> None:
     """Expiry is based on the newest recorded_at across HTTP, gRPC, and WS interactions."""
     path = os.path.join(str(tmp_path), "mixed.yaml")
     c = RustCassette()
@@ -460,7 +460,7 @@ def _write_vcr_cassette(path: str, interactions: list[dict[str, object]]) -> Non
         yaml.dump(data, f)
 
 
-def test_vcr_format_json_response(tmp_path: object) -> None:
+def test_vcr_format_json_response(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -491,7 +491,7 @@ def test_vcr_format_json_response(tmp_path: object) -> None:
     assert i.response.body.content == {"key": "value", "num": 42}
 
 
-def test_vcr_format_text_response(tmp_path: object) -> None:
+def test_vcr_format_text_response(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -517,7 +517,7 @@ def test_vcr_format_text_response(tmp_path: object) -> None:
     assert i.response.body.content == "<html>hello</html>"
 
 
-def test_vcr_format_null_response_body(tmp_path: object) -> None:
+def test_vcr_format_null_response_body(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -542,7 +542,7 @@ def test_vcr_format_null_response_body(tmp_path: object) -> None:
     assert c.interactions[0].response.body.body_type == "none"
 
 
-def test_vcr_format_empty_string_request_body(tmp_path: object) -> None:
+def test_vcr_format_empty_string_request_body(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -566,7 +566,7 @@ def test_vcr_format_empty_string_request_body(tmp_path: object) -> None:
     assert c.interactions[0].request.body.body_type == "none"
 
 
-def test_vcr_format_string_request_body(tmp_path: object) -> None:
+def test_vcr_format_string_request_body(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -594,7 +594,7 @@ def test_vcr_format_string_request_body(tmp_path: object) -> None:
     assert i.response.body.content == {"reply": "hi"}
 
 
-def test_vcr_format_saves_as_cassetter(tmp_path: object) -> None:
+def test_vcr_format_saves_as_cassetter(tmp_path: Path) -> None:
     vcr_path = os.path.join(str(tmp_path), "vcr.yaml")
     out_path = os.path.join(str(tmp_path), "out.yaml")
     _write_vcr_cassette(
@@ -628,7 +628,7 @@ def test_vcr_format_saves_as_cassetter(tmp_path: object) -> None:
     assert resp["body"]["content"] == {"ok": True}
 
 
-def test_vcr_format_playback(tmp_path: object) -> None:
+def test_vcr_format_playback(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "vcr.yaml")
     _write_vcr_cassette(
         path,
@@ -655,7 +655,7 @@ def test_vcr_format_playback(tmp_path: object) -> None:
     assert response.body.content == {"users": []}
 
 
-def test_vcr_format_parsed_body(tmp_path: object) -> None:
+def test_vcr_format_parsed_body(tmp_path: Path) -> None:
     """pydantic-ai style serializer: structured `parsed_body` instead of `body`."""
     path = os.path.join(str(tmp_path), "parsed.yaml")
     _write_vcr_cassette(
@@ -684,7 +684,7 @@ def test_vcr_format_parsed_body(tmp_path: object) -> None:
     assert i.response.body.content["choices"][0]["message"]["content"] == "hello"
 
 
-def test_vcr_format_missing_version(tmp_path: object) -> None:
+def test_vcr_format_missing_version(tmp_path: Path) -> None:
     """Cassettes written without a top-level version key load with version 1."""
     path = os.path.join(str(tmp_path), "no_version.yaml")
     data = {
@@ -703,7 +703,7 @@ def test_vcr_format_missing_version(tmp_path: object) -> None:
     assert len(c) == 1
 
 
-def test_parsed_body_saves_as_cassetter_format(tmp_path: object) -> None:
+def test_parsed_body_saves_as_cassetter_format(tmp_path: Path) -> None:
     """parsed_body cassettes are rewritten in cassetter's own body format on save."""
     path = os.path.join(str(tmp_path), "parsed.yaml")
     _write_vcr_cassette(
@@ -731,7 +731,7 @@ def test_parsed_body_saves_as_cassetter_format(tmp_path: object) -> None:
     assert request["body"] == {"type": "json", "content": {"q": 1}}
 
 
-def test_vcr_format_binary_body_and_headers(tmp_path: object) -> None:
+def test_vcr_format_binary_body_and_headers(tmp_path: Path) -> None:
     """PyYAML !!binary scalars (bodies and header values) decode to real bytes."""
     path = os.path.join(str(tmp_path), "binary.yaml")
     data = {
@@ -756,7 +756,7 @@ def test_vcr_format_binary_body_and_headers(tmp_path: object) -> None:
     assert response.body.content == b"\x00\x01\xffbinary-payload"
 
 
-def test_vcr_format_bare_mapping_request_body(tmp_path: object) -> None:
+def test_vcr_format_bare_mapping_request_body(tmp_path: Path) -> None:
     """A structured dict directly under request.body (aiohttp recordings) loads as JSON."""
     path = os.path.join(str(tmp_path), "mapping.yaml")
     data = {
@@ -786,7 +786,7 @@ def test_match_config_rejects_unknown_matcher() -> None:
         MatchConfig(match_on=["method", "url"])  # type: ignore[list-item]
 
 
-def test_toml_save_refuses_grpc_interactions(tmp_path: object) -> None:
+def test_toml_save_refuses_grpc_interactions(tmp_path: Path) -> None:
     c = RustCassette()
     c.add_grpc_interaction(
         GrpcInteraction(
@@ -799,7 +799,7 @@ def test_toml_save_refuses_grpc_interactions(tmp_path: object) -> None:
         c.save(os.path.join(str(tmp_path), "grpc.toml"))
 
 
-def test_saved_headers_are_sorted(tmp_path: object) -> None:
+def test_saved_headers_are_sorted(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "sorted.yaml")
     c = RustCassette()
     c.add_interaction(
@@ -834,7 +834,7 @@ def test_scrub_multibyte_query_no_panic() -> None:
     assert "api_key=[FILTERED]" in scrubbed.request.uri
 
 
-def test_once_with_existing_cassette_is_replay_only(tmp_path: object) -> None:
+def test_once_with_existing_cassette_is_replay_only(tmp_path: Path) -> None:
     """`once` must not record (or hit the network) when the cassette already exists."""
     path = os.path.join(str(tmp_path), "once.yaml")
     recorder = Cassette(path, record_mode=RecordMode.ALL)
@@ -862,14 +862,14 @@ def test_once_with_existing_cassette_is_replay_only(tmp_path: object) -> None:
         cassette.play("GET", "https://example.com/unknown", {}, None)
 
 
-def test_once_without_cassette_records(tmp_path: object) -> None:
+def test_once_without_cassette_records(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "fresh.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ONCE)
     cassette.load()
     assert cassette.can_record is True
 
 
-def test_once_rerecord_expiry_allows_recording(tmp_path: object) -> None:
+def test_once_rerecord_expiry_allows_recording(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "expired.yaml")
     recorder = Cassette(path, record_mode=RecordMode.ALL)
     recorder.load()
@@ -895,7 +895,7 @@ def test_once_rerecord_expiry_allows_recording(tmp_path: object) -> None:
     assert cassette.can_record is True
 
 
-def test_play_matches_uri_with_filtered_query_param(tmp_path: object) -> None:
+def test_play_matches_uri_with_filtered_query_param(tmp_path: Path) -> None:
     """Scrubbed query params must not break replay matching."""
     path = os.path.join(str(tmp_path), "filtered.yaml")
     recorder = Cassette(path, record_mode=RecordMode.ALL)
@@ -927,7 +927,7 @@ def test_play_matches_uri_with_filtered_query_param(tmp_path: object) -> None:
     assert response.status == 200
 
 
-def test_play_matches_scrubbed_json_body(tmp_path: object) -> None:
+def test_play_matches_scrubbed_json_body(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "body_match.yaml")
     config = MatchConfig(match_on=["method", "uri", "json_body"])
     recorder = Cassette(path, record_mode=RecordMode.ALL, match_config=config)
@@ -954,12 +954,12 @@ def test_play_matches_scrubbed_json_body(tmp_path: object) -> None:
     assert response.status == 200
 
 
-def test_invalid_on_expiry_rejected(tmp_path: object) -> None:
+def test_invalid_on_expiry_rejected(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="invalid on_expiry"):
         Cassette(os.path.join(str(tmp_path), "x.yaml"), on_expiry="error")
 
 
-def test_all_mode_truncates_stale_cassette(tmp_path: object) -> None:
+def test_all_mode_truncates_stale_cassette(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "stale.yaml")
     recorder = Cassette(path, record_mode=RecordMode.ALL)
     recorder.load()
@@ -1026,7 +1026,7 @@ def test_rewrite_mode_without_existing_cassette(tmp_path: Path) -> None:
     assert not os.path.exists(path)
 
 
-def test_save_preserves_file_permissions(tmp_path: object) -> None:
+def test_save_preserves_file_permissions(tmp_path: Path) -> None:
     """Atomic save must keep a restrictive mode on an existing cassette."""
     if sys.platform == "win32":  # pragma: no cover
         pytest.skip("POSIX permissions only")
@@ -1060,7 +1060,7 @@ def _save_interaction(path: str, method: str, uri: str, body_text: str) -> None:
     c.save(path)
 
 
-def test_uri_normalizer_matches_normalized_equivalent(tmp_path: object) -> None:
+def test_uri_normalizer_matches_normalized_equivalent(tmp_path: Path) -> None:
     """A normalizer applied to both sides lets region-variant URIs replay."""
     path = os.path.join(str(tmp_path), "regions.yaml")
     _save_interaction(path, "POST", "https://svc.us-east-2.example.com/model/m:0/run", "east-2")
@@ -1077,7 +1077,7 @@ def test_uri_normalizer_matches_normalized_equivalent(tmp_path: object) -> None:
     assert cassette.play_count == 1
 
 
-def test_uri_normalizer_still_rejects_distinct_uris(tmp_path: object) -> None:
+def test_uri_normalizer_still_rejects_distinct_uris(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "distinct.yaml")
     _save_interaction(path, "GET", "https://svc.us-east-2.example.com/a", "a")
 
@@ -1088,7 +1088,7 @@ def test_uri_normalizer_still_rejects_distinct_uris(tmp_path: object) -> None:
         cassette.play("GET", "https://svc.us-east-2.example.com/other", {}, None)
 
 
-def test_uri_normalizer_applies_to_recorded_interactions(tmp_path: object) -> None:
+def test_uri_normalizer_applies_to_recorded_interactions(tmp_path: Path) -> None:
     """An interaction recorded in this session is matchable through the normalizer."""
     path = os.path.join(str(tmp_path), "recorded.yaml")
     cassette = Cassette(
@@ -1111,7 +1111,7 @@ def test_uri_normalizer_applies_to_recorded_interactions(tmp_path: object) -> No
     assert response.body.content == "items"
 
 
-def test_without_uri_normalizer_region_variant_does_not_match(tmp_path: object) -> None:
+def test_without_uri_normalizer_region_variant_does_not_match(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "no-normalizer.yaml")
     _save_interaction(path, "POST", "https://svc.us-east-2.example.com/run", "east-2")
 
@@ -1122,7 +1122,7 @@ def test_without_uri_normalizer_region_variant_does_not_match(tmp_path: object) 
         cassette.play("POST", "https://svc.us-east-1.example.com/run", {}, None)
 
 
-def test_corrupt_cassette_raises_cassette_load_error(tmp_path: object) -> None:
+def test_corrupt_cassette_raises_cassette_load_error(tmp_path: Path) -> None:
     """A corrupt cassette surfaces as a library error, not a bare Rust ValueError."""
     path = os.path.join(str(tmp_path), "corrupt.yaml")
     with open(path, "w") as f:
@@ -1145,7 +1145,7 @@ def _record(cassette: Cassette, method: str, uri: str, body: bytes | None, reply
     )
 
 
-def test_save_writes_interactions_in_canonical_order(tmp_path: object) -> None:
+def test_save_writes_interactions_in_canonical_order(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "canonical.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -1160,7 +1160,7 @@ def test_save_writes_interactions_in_canonical_order(tmp_path: object) -> None:
     ]
 
 
-def test_save_keeps_order_the_matcher_relies_on(tmp_path: object) -> None:
+def test_save_keeps_order_the_matcher_relies_on(tmp_path: Path) -> None:
     """Interactions the matcher cannot tell apart must not be reordered.
 
     Replay takes the first unplayed match, so their order is what decides which
@@ -1179,7 +1179,7 @@ def test_save_keeps_order_the_matcher_relies_on(tmp_path: object) -> None:
     assert replayed.play("POST", uri, {}, b'{"q": "zebra"}').body.content == "first"
 
 
-def test_save_sorts_by_body_when_it_is_matched_on(tmp_path: object) -> None:
+def test_save_sorts_by_body_when_it_is_matched_on(tmp_path: Path) -> None:
     """Matching on the body makes it safe to order by, so it is used."""
     path = os.path.join(str(tmp_path), "by-body.yaml")
     uri = "https://api.example.com/chat"
@@ -1197,7 +1197,7 @@ def test_save_sorts_by_body_when_it_is_matched_on(tmp_path: object) -> None:
     assert [i.response.body.content for i in saved.interactions] == ["aardvark", "zebra"]
 
 
-def test_newly_recorded_interactions_follow_loaded_ones(tmp_path: object) -> None:
+def test_newly_recorded_interactions_follow_loaded_ones(tmp_path: Path) -> None:
     """An appended interaction sorts after the loaded one it ties with."""
     path = os.path.join(str(tmp_path), "appended.yaml")
     uri = "https://api.example.com/poll"
@@ -1216,7 +1216,7 @@ def test_newly_recorded_interactions_follow_loaded_ones(tmp_path: object) -> Non
     assert [i.response.body.content for i in saved.interactions] == ["loaded", "appended"]
 
 
-def test_uri_normalizer_collisions_keep_request_order(tmp_path: object) -> None:
+def test_uri_normalizer_collisions_keep_request_order(tmp_path: Path) -> None:
     """URIs the normalizer collapses into one must not be split by the sort.
 
     Matching compares the normalized URI, so these two are interchangeable at

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,6 +13,7 @@ import os
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Any
 
 import anyio
@@ -63,7 +64,7 @@ def _make_cassette(path: str, url: str, response_data: dict[str, object]) -> str
 
 
 @pytest.mark.anyio
-async def test_two_concurrent_async_cassettes(tmp_path: object) -> None:
+async def test_two_concurrent_async_cassettes(tmp_path: Path) -> None:
     """Two async tasks using different cassettes concurrently get correct responses."""
     dir_path = str(tmp_path)
     path_a = _make_cassette(os.path.join(dir_path, "a.yaml"), "https://api.example.com/data", {"source": "a"})
@@ -88,7 +89,7 @@ async def test_two_concurrent_async_cassettes(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_many_concurrent_async_cassettes(tmp_path: object) -> None:
+async def test_many_concurrent_async_cassettes(tmp_path: Path) -> None:
     """N concurrent async tasks each get their own cassette - like Go's 50 goroutine test."""
     dir_path = str(tmp_path)
     n = 50
@@ -115,7 +116,7 @@ async def test_many_concurrent_async_cassettes(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_nested_cassettes(tmp_path: object) -> None:
+async def test_nested_cassettes(tmp_path: Path) -> None:
     """Inner use_cassette overrides the outer one; outer is restored after inner exits."""
     dir_path = str(tmp_path)
     path_outer = _make_cassette(
@@ -155,7 +156,7 @@ async def test_no_cassette_passthrough() -> None:
 
 
 @pytest.mark.anyio
-async def test_concurrent_record_and_replay(tmp_path: object) -> None:
+async def test_concurrent_record_and_replay(tmp_path: Path) -> None:
     """One task replays from cassette A while another records to cassette B - no cross-contamination."""
     dir_path = str(tmp_path)
     path_replay = _make_cassette(
@@ -183,7 +184,7 @@ async def test_concurrent_record_and_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_concurrent_cassettes_different_urls(tmp_path: object) -> None:
+async def test_concurrent_cassettes_different_urls(tmp_path: Path) -> None:
     """Concurrent cassettes targeting different URLs don't interfere."""
     dir_path = str(tmp_path)
     path_a = _make_cassette(os.path.join(dir_path, "a.yaml"), "https://api-a.example.com/data", {"api": "a"})
@@ -212,7 +213,7 @@ async def test_concurrent_cassettes_different_urls(tmp_path: object) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_threadpool_concurrent_cassettes(tmp_path: object) -> None:
+def test_threadpool_concurrent_cassettes(tmp_path: Path) -> None:
     """Multiple threads each using their own cassette via ThreadPoolExecutor."""
     dir_path = str(tmp_path)
     n = 10
@@ -251,7 +252,7 @@ def test_threadpool_concurrent_cassettes(tmp_path: object) -> None:
         release_patches([HttpxInterceptor])
 
 
-def test_threadpool_with_context_propagation(tmp_path: object) -> None:
+def test_threadpool_with_context_propagation(tmp_path: Path) -> None:
     """ThreadPoolExecutor with explicit context propagation via copy_context."""
     dir_path = str(tmp_path)
     path = _make_cassette(os.path.join(dir_path, "ctx.yaml"), "https://api.example.com/data", {"propagated": True})
@@ -272,7 +273,7 @@ def test_threadpool_with_context_propagation(tmp_path: object) -> None:
     assert result == {"propagated": True}
 
 
-def test_threadpool_no_cassette_in_thread(tmp_path: object) -> None:
+def test_threadpool_no_cassette_in_thread(tmp_path: Path) -> None:
     """Without context propagation, threads have no cassette - requests pass through."""
     acquire_patches([HttpxInterceptor])
     try:
@@ -294,7 +295,7 @@ def test_threadpool_no_cassette_in_thread(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_concurrent_tasks_with_no_match_isolation(tmp_path: object) -> None:
+async def test_concurrent_tasks_with_no_match_isolation(tmp_path: Path) -> None:
     """NoMatchError in one task doesn't affect another concurrent task."""
     dir_path = str(tmp_path)
     path_a = _make_cassette(os.path.join(dir_path, "a.yaml"), "https://api.example.com/data", {"source": "a"})
@@ -350,7 +351,7 @@ def test_patch_refcounting() -> None:
     assert httpx.AsyncClient.__init__ is original_init
 
 
-def test_thread_without_context_falls_back_to_active_cassette(tmp_path: object) -> None:
+def test_thread_without_context_falls_back_to_active_cassette(tmp_path: Path) -> None:
     """Threads with no propagated context see the active cassette.
 
     Libraries like Temporal and DBOS run workflow code on worker threads
@@ -373,7 +374,7 @@ def test_thread_without_context_falls_back_to_active_cassette(tmp_path: object) 
     assert result == {"fallback": "hit"}
 
 
-def test_thread_context_cassette_wins_over_fallback(tmp_path: object) -> None:
+def test_thread_context_cassette_wins_over_fallback(tmp_path: Path) -> None:
     """A cassette set in the thread's own context takes priority over the fallback."""
     dir_path = str(tmp_path)
     path_outer = _make_cassette(os.path.join(dir_path, "f-outer.yaml"), "https://api.example.com/data", {"c": "outer"})
@@ -397,7 +398,7 @@ def test_thread_context_cassette_wins_over_fallback(tmp_path: object) -> None:
     assert result == {"c": "own"}
 
 
-def test_fallback_removed_out_of_order(tmp_path: object) -> None:
+def test_fallback_removed_out_of_order(tmp_path: Path) -> None:
     """Exiting an earlier cassette leaves a later still-active one as the fallback."""
     from cassetter._state import get_current_cassette, pop_fallback_cassette, push_fallback_cassette
 
@@ -418,7 +419,7 @@ def test_fallback_removed_out_of_order(tmp_path: object) -> None:
     assert get_current_cassette() is None
 
 
-def test_no_fallback_while_several_cassettes_are_active(tmp_path: object) -> None:
+def test_no_fallback_while_several_cassettes_are_active(tmp_path: Path) -> None:
     """A context-less thread inherits nothing rather than another task's cassette."""
     from cassetter._state import get_current_cassette, pop_fallback_cassette, push_fallback_cassette
 
@@ -473,7 +474,7 @@ def _recorded(path: str, field: str) -> list[str]:
 
 
 @pytest.mark.anyio
-async def test_saved_order_does_not_depend_on_response_order(tmp_path: object) -> None:
+async def test_saved_order_does_not_depend_on_response_order(tmp_path: Path) -> None:
     """Two runs of the same concurrent suite write the same cassette."""
     dir_path = str(tmp_path)
     requests = [("https://api.example.com/b", "b"), ("https://api.example.com/a", "a")]
@@ -489,7 +490,7 @@ async def test_saved_order_does_not_depend_on_response_order(tmp_path: object) -
 
 
 @pytest.mark.anyio
-async def test_indistinguishable_interactions_keep_request_order(tmp_path: object) -> None:
+async def test_indistinguishable_interactions_keep_request_order(tmp_path: Path) -> None:
     """What the matcher cannot tell apart is written in the order it was sent.
 
     Both requests share a method and URI, so the sort has to leave them alone -
@@ -528,7 +529,7 @@ async def test_indistinguishable_interactions_keep_request_order(tmp_path: objec
     assert _recorded(path, "body") == ["first", "second"]
 
 
-def test_concurrent_records_keep_interactions_paired_with_their_position(tmp_path: object) -> None:
+def test_concurrent_records_keep_interactions_paired_with_their_position(tmp_path: Path) -> None:
     """Appending the interaction and its position must not interleave.
 
     A recorder slipping between the two leaves an interaction holding another

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 
@@ -27,7 +29,7 @@ def _make_cassette(path: str) -> str:
 
 
 @pytest.mark.anyio
-async def test_use_cassette_with_filter_headers(tmp_path: object) -> None:
+async def test_use_cassette_with_filter_headers(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode="none", filter_headers=["x-custom"]):
         async with httpx.AsyncClient() as client:
@@ -36,7 +38,7 @@ async def test_use_cassette_with_filter_headers(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_use_cassette_with_filter_query_parameters(tmp_path: object) -> None:
+async def test_use_cassette_with_filter_query_parameters(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode="none", filter_query_parameters=["token"]):
         async with httpx.AsyncClient() as client:
@@ -45,7 +47,7 @@ async def test_use_cassette_with_filter_query_parameters(tmp_path: object) -> No
 
 
 @pytest.mark.anyio
-async def test_use_cassette_with_body_scrub_patterns(tmp_path: object) -> None:
+async def test_use_cassette_with_body_scrub_patterns(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode="none", body_scrub_patterns=["secret"]):
         async with httpx.AsyncClient() as client:
@@ -54,7 +56,7 @@ async def test_use_cassette_with_body_scrub_patterns(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_use_cassette_with_filter_replacement(tmp_path: object) -> None:
+async def test_use_cassette_with_filter_replacement(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode="none", filter_replacement="[REDACTED]"):
         async with httpx.AsyncClient() as client:
@@ -63,7 +65,7 @@ async def test_use_cassette_with_filter_replacement(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_use_cassette_string_record_mode(tmp_path: object) -> None:
+async def test_use_cassette_string_record_mode(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode="none"):
         async with httpx.AsyncClient() as client:
@@ -72,7 +74,7 @@ async def test_use_cassette_string_record_mode(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_use_cassette_enum_record_mode(tmp_path: object) -> None:
+async def test_use_cassette_enum_record_mode(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with use_cassette(path, record_mode=RecordMode.NONE):
         async with httpx.AsyncClient() as client:
@@ -119,7 +121,7 @@ def test_resolve_interceptors_auto_detect_no_interceptors(monkeypatch: pytest.Mo
 
 
 @pytest.mark.anyio
-async def test_use_cassette_expired_warns(tmp_path: object) -> None:
+async def test_use_cassette_expired_warns(tmp_path: Path) -> None:
     path = _make_cassette(f"{tmp_path}/test.yaml")
     with pytest.warns(CassetteExpiredWarning):
         with use_cassette(path, record_mode="none", max_age="1h", on_expiry="warn"):

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import grpc
 import grpc.aio
@@ -269,7 +270,7 @@ def test_rust_cassette_repr_includes_grpc() -> None:
 # --- Cassette roundtrip (save/load) ---
 
 
-def test_grpc_save_and_load(tmp_path: object) -> None:
+def test_grpc_save_and_load(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "grpc.yaml")
     c = RustCassette()
     c.add_grpc_interaction(
@@ -297,7 +298,7 @@ def test_grpc_save_and_load(tmp_path: object) -> None:
     assert grpc_i.json_debug == {"request": {"input": "Hello"}, "response": {"output": "Hi"}}
 
 
-def test_ws_save_and_load(tmp_path: object) -> None:
+def test_ws_save_and_load(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws.yaml")
     c = RustCassette()
     c.add_ws_interaction(
@@ -327,7 +328,7 @@ def test_ws_save_and_load(tmp_path: object) -> None:
     assert ws_i.frames[1].offset_ms == 120
 
 
-def test_mixed_protocol_roundtrip(tmp_path: object) -> None:
+def test_mixed_protocol_roundtrip(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "mixed.yaml")
     c = RustCassette()
     c.add_interaction(
@@ -354,7 +355,7 @@ def test_mixed_protocol_roundtrip(tmp_path: object) -> None:
     assert len(c2) == 3
 
 
-def test_backward_compat_http_only(tmp_path: object) -> None:
+def test_backward_compat_http_only(tmp_path: Path) -> None:
     """Existing HTTP-only cassettes still load without grpc/ws sections."""
     path = os.path.join(str(tmp_path), "http_only.yaml")
     c = RustCassette()
@@ -401,7 +402,7 @@ def test_play_ws_before_load_raises() -> None:
         cassette.play_ws("wss://example.com")
 
 
-def test_record_and_play_grpc(tmp_path: object) -> None:
+def test_record_and_play_grpc(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "grpc_test.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -419,7 +420,7 @@ def test_record_and_play_grpc(tmp_path: object) -> None:
     assert resp.body.body_type == "binary"
 
 
-def test_play_grpc_no_match_raises(tmp_path: object) -> None:
+def test_play_grpc_no_match_raises(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "grpc_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
     cassette.load()
@@ -428,7 +429,7 @@ def test_play_grpc_no_match_raises(tmp_path: object) -> None:
         cassette.play_grpc("/pkg.Svc/Unknown")
 
 
-def test_record_ws_interaction(tmp_path: object) -> None:
+def test_record_ws_interaction(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws_test.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -441,7 +442,7 @@ def test_record_ws_interaction(tmp_path: object) -> None:
     assert len(cassette.ws_interactions) == 1
 
 
-def test_record_ws_scrubs_headers(tmp_path: object) -> None:
+def test_record_ws_scrubs_headers(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws_scrub.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -454,7 +455,7 @@ def test_record_ws_scrubs_headers(tmp_path: object) -> None:
     assert recorded.headers["x-custom"] == ["keep"]
 
 
-def test_record_ws_scrubs_frame_bodies(tmp_path: object) -> None:
+def test_record_ws_scrubs_frame_bodies(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws_frame_scrub.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -472,7 +473,7 @@ def test_record_ws_scrubs_frame_bodies(tmp_path: object) -> None:
     assert '"password":"[FILTERED]"' in recorded.frames[1].body.content
 
 
-def test_record_grpc_scrubs_metadata_and_json_debug(tmp_path: object) -> None:
+def test_record_grpc_scrubs_metadata_and_json_debug(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "grpc_scrub.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -495,7 +496,7 @@ def test_record_grpc_scrubs_metadata_and_json_debug(tmp_path: object) -> None:
     assert recorded.request.body.content == b"\x0a\x0b"
 
 
-def test_play_ws_interaction(tmp_path: object) -> None:
+def test_play_ws_interaction(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws_play.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -511,7 +512,7 @@ def test_play_ws_interaction(tmp_path: object) -> None:
     assert len(interaction.frames) == 2
 
 
-def test_play_ws_no_match_raises(tmp_path: object) -> None:
+def test_play_ws_no_match_raises(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "ws_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
     cassette.load()
@@ -520,7 +521,7 @@ def test_play_ws_no_match_raises(tmp_path: object) -> None:
         cassette.play_ws("wss://unknown.com")
 
 
-def test_grpc_ws_save_persists(tmp_path: object) -> None:
+def test_grpc_ws_save_persists(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "mixed_persist.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
     cassette.load()
@@ -672,7 +673,7 @@ def test_grpc_interceptor_install_uninstall() -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_unary_replay(tmp_path: object) -> None:
+async def test_unary_unary_replay(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_replay.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -700,7 +701,7 @@ async def test_unary_unary_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_unary_no_match_raises(tmp_path: object) -> None:
+async def test_unary_unary_no_match_raises(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
@@ -721,7 +722,7 @@ async def test_unary_unary_no_match_raises(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_stream_replay(tmp_path: object) -> None:
+async def test_unary_stream_replay(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_stream.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -752,7 +753,7 @@ async def test_unary_stream_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_stream_no_match_raises(tmp_path: object) -> None:
+async def test_unary_stream_no_match_raises(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
@@ -769,7 +770,7 @@ async def test_unary_stream_no_match_raises(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_unary_replay(tmp_path: object) -> None:
+async def test_stream_unary_replay(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_cstream.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -801,7 +802,7 @@ async def test_stream_unary_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_unary_no_match_raises(tmp_path: object) -> None:
+async def test_stream_unary_no_match_raises(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
@@ -820,7 +821,7 @@ async def test_stream_unary_no_match_raises(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_stream_replay(tmp_path: object) -> None:
+async def test_stream_stream_replay(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_bidi.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -854,7 +855,7 @@ async def test_stream_stream_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_stream_no_match_raises(tmp_path: object) -> None:
+async def test_stream_stream_no_match_raises(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
@@ -978,7 +979,7 @@ async def test_replay_wsasync_iter() -> None:
 
 
 @pytest.mark.anyio
-async def test_record_ws_frames(tmp_path: object) -> None:
+async def test_record_ws_frames(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_record.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1012,7 +1013,7 @@ async def test_record_ws_frames(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_record_ws_context_manager(tmp_path: object) -> None:
+async def test_record_ws_context_manager(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_ctx.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1041,7 +1042,7 @@ async def test_record_ws_context_manager(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_record_ws_binary_frames(tmp_path: object) -> None:
+async def test_record_ws_binary_frames(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_binary.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1073,7 +1074,7 @@ async def test_record_ws_binary_frames(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_record_wsasync_iter(tmp_path: object) -> None:
+async def test_record_wsasync_iter(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_iter.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1108,7 +1109,7 @@ async def test_record_wsasync_iter(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_patched_connect_replay(tmp_path: object) -> None:
+async def test_patched_connect_replay(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_connect.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1130,7 +1131,7 @@ async def test_patched_connect_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_patched_connect_no_match_raises(tmp_path: object) -> None:
+async def test_patched_connect_no_match_raises(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_empty.yaml")
     cassette = Cassette(path, record_mode=RecordMode.NONE)
@@ -1165,7 +1166,7 @@ def test_websocket_interceptor_install_uninstall() -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_unary_record(tmp_path: object) -> None:
+async def test_unary_unary_record(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_rec.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1195,7 +1196,7 @@ async def test_unary_unary_record(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_unary_stream_record(tmp_path: object) -> None:
+async def test_unary_stream_record(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_rec_stream.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1235,7 +1236,7 @@ async def test_unary_stream_record(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_unary_record(tmp_path: object) -> None:
+async def test_stream_unary_record(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_rec_cstream.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1268,7 +1269,7 @@ async def test_stream_unary_record(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_stream_record(tmp_path: object) -> None:
+async def test_stream_stream_record(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "grpc_rec_bidi.yaml")
     cassette = Cassette(path, record_mode=RecordMode.ALL)
@@ -1454,7 +1455,7 @@ async def test_grpc_replay_unknown_status_code_maps_to_unknown() -> None:
 
 
 @pytest.mark.anyio
-async def test_patched_connect_await_form(tmp_path: object) -> None:
+async def test_patched_connect_await_form(tmp_path: Path) -> None:
     """`ws = await websockets.connect(uri)` (not just `async with`) must work."""
 
     path = os.path.join(str(tmp_path), "ws_await.yaml")
@@ -1474,7 +1475,7 @@ async def test_patched_connect_await_form(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_patched_connect_async_for_form(tmp_path: object) -> None:
+async def test_patched_connect_async_for_form(tmp_path: Path) -> None:
     """`async for ws in connect(...)` reconnect loop yields one connection."""
 
     path = os.path.join(str(tmp_path), "ws_for.yaml")
@@ -1498,7 +1499,7 @@ async def test_patched_connect_async_for_form(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_ws_bypass_ignores_localhost(tmp_path: object) -> None:
+async def test_ws_bypass_ignores_localhost(tmp_path: Path) -> None:
     """A bypassed WS URI must not consult the cassette (would raise NoMatch here)."""
 
     path = os.path.join(str(tmp_path), "ws_bypass.yaml")

--- a/tests/test_ignore_localhost.py
+++ b/tests/test_ignore_localhost.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import httpx
 import pytest
@@ -14,7 +15,7 @@ pytest_plugins = ("anyio",)
 
 
 @pytest.fixture
-def cassette_path(tmp_path: object) -> str:
+def cassette_path(tmp_path: Path) -> str:
     return os.path.join(str(tmp_path), "ignore_localhost.yaml")
 
 

--- a/tests/test_intercept_aiohttp.py
+++ b/tests/test_intercept_aiohttp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import aiohttp
@@ -44,7 +45,7 @@ def _preload_cassette(path: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_interceptor_replay(tmp_path: object) -> None:
+async def test_interceptor_replay(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -57,7 +58,7 @@ async def test_interceptor_replay(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_interceptor_no_match_cant_record(tmp_path: object) -> None:
+async def test_interceptor_no_match_cant_record(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -68,7 +69,7 @@ async def test_interceptor_no_match_cant_record(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_interceptor_record(tmp_path: object) -> None:
+async def test_interceptor_record(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "test.yaml")
 

--- a/tests/test_intercept_edges.py
+++ b/tests/test_intercept_edges.py
@@ -9,6 +9,7 @@ is touched.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import aiohttp
 import httpx
@@ -55,7 +56,7 @@ def _rewrite_to(target: str) -> BeforeRecordRequest:
 # --- requests ---
 
 
-def test_requests_bypass_passes_through(tmp_path: object) -> None:
+def test_requests_bypass_passes_through(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "req_bypass.yaml")
     _preload(path, "http://example.com/x")
@@ -64,7 +65,7 @@ def test_requests_bypass_passes_through(tmp_path: object) -> None:
             requests.get(_REFUSED)
 
 
-def test_requests_hook_rewrites_to_match(tmp_path: object) -> None:
+def test_requests_hook_rewrites_to_match(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "req_hook.yaml")
     _preload(path, "https://api.example.com/real")
@@ -78,7 +79,7 @@ def test_requests_hook_rewrites_to_match(tmp_path: object) -> None:
     assert resp.status_code == 200
 
 
-def test_requests_hook_skip_recording_passes_through(tmp_path: object) -> None:
+def test_requests_hook_skip_recording_passes_through(tmp_path: Path) -> None:
 
     def hook(request: RawRequest) -> RawRequest:
         raise SkipRecording
@@ -92,7 +93,7 @@ def test_requests_hook_skip_recording_passes_through(tmp_path: object) -> None:
 # --- urllib3 ---
 
 
-def test_urllib3_bypass_passes_through(tmp_path: object) -> None:
+def test_urllib3_bypass_passes_through(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "u3_bypass.yaml")
     _preload(path, "http://example.com/x")
@@ -101,7 +102,7 @@ def test_urllib3_bypass_passes_through(tmp_path: object) -> None:
             urllib3.PoolManager().request("GET", _REFUSED, retries=False)
 
 
-def test_urllib3_hook_rewrites_to_match(tmp_path: object) -> None:
+def test_urllib3_hook_rewrites_to_match(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "u3_hook.yaml")
     _preload(path, "https://api.example.com/real")
@@ -119,7 +120,7 @@ def test_urllib3_hook_rewrites_to_match(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_aiohttp_bypass_passes_through(tmp_path: object) -> None:
+async def test_aiohttp_bypass_passes_through(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "aio_bypass.yaml")
     _preload(path, "http://example.com/x")
@@ -130,7 +131,7 @@ async def test_aiohttp_bypass_passes_through(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_aiohttp_hook_rewrites_to_match(tmp_path: object) -> None:
+async def test_aiohttp_hook_rewrites_to_match(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "aio_hook.yaml")
     _preload(path, "https://api.example.com/real")
@@ -148,7 +149,7 @@ async def test_aiohttp_hook_rewrites_to_match(tmp_path: object) -> None:
 # --- pyreqwest ---
 
 
-def test_pyreqwest_bypass_passes_through(tmp_path: object) -> None:
+def test_pyreqwest_bypass_passes_through(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "prq_bypass.yaml")
     _preload(path, "http://example.com/x")
@@ -157,7 +158,7 @@ def test_pyreqwest_bypass_passes_through(tmp_path: object) -> None:
             pri.Client().get(_REFUSED)
 
 
-def test_pyreqwest_hook_rewrites_to_match(tmp_path: object) -> None:
+def test_pyreqwest_hook_rewrites_to_match(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "prq_hook.yaml")
     _preload(path, "https://api.example.com/real")
@@ -171,7 +172,7 @@ def test_pyreqwest_hook_rewrites_to_match(tmp_path: object) -> None:
     assert resp.status_code == 200
 
 
-def test_pyreqwest_replay_with_bytes_body(tmp_path: object) -> None:
+def test_pyreqwest_replay_with_bytes_body(tmp_path: Path) -> None:
     """A bytes `data=` body exercises extract_body's bytes branch."""
 
     path = os.path.join(str(tmp_path), "prq_body.yaml")
@@ -189,7 +190,7 @@ def test_pyreqwest_replay_with_bytes_body(tmp_path: object) -> None:
     assert resp.status_code == 200
 
 
-def test_urllib3_hook_skip_recording_passes_through(tmp_path: object) -> None:
+def test_urllib3_hook_skip_recording_passes_through(tmp_path: Path) -> None:
 
     def hook(request: RawRequest) -> RawRequest:
         raise SkipRecording
@@ -201,7 +202,7 @@ def test_urllib3_hook_skip_recording_passes_through(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_aiohttp_hook_skip_recording_passes_through(tmp_path: object) -> None:
+async def test_aiohttp_hook_skip_recording_passes_through(tmp_path: Path) -> None:
 
     def hook(request: RawRequest) -> RawRequest:
         raise SkipRecording
@@ -213,7 +214,7 @@ async def test_aiohttp_hook_skip_recording_passes_through(tmp_path: object) -> N
                 await session.get(_REFUSED)
 
 
-def test_pyreqwest_hook_skip_recording_passes_through(tmp_path: object) -> None:
+def test_pyreqwest_hook_skip_recording_passes_through(tmp_path: Path) -> None:
 
     def hook(request: RawRequest) -> RawRequest:
         raise SkipRecording
@@ -225,7 +226,7 @@ def test_pyreqwest_hook_skip_recording_passes_through(tmp_path: object) -> None:
 
 
 @pytest.mark.anyio
-async def test_httpx_async_hook_rewrites_to_match(tmp_path: object) -> None:
+async def test_httpx_async_hook_rewrites_to_match(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "hx_hook.yaml")
     _preload(path, "https://api.example.com/real")

--- a/tests/test_intercept_httpx.py
+++ b/tests/test_intercept_httpx.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
 
 import httpx
 import pytest
@@ -17,7 +18,7 @@ pytest_plugins = ("anyio",)
 
 
 @pytest.fixture
-def cassette_path(tmp_path: object) -> str:
+def cassette_path(tmp_path: Path) -> str:
     return os.path.join(str(tmp_path), "httpx_test.yaml")
 
 

--- a/tests/test_intercept_httpx2.py
+++ b/tests/test_intercept_httpx2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import httpx
 import httpx2
@@ -17,7 +18,7 @@ pytest_plugins = ("anyio",)
 
 
 @pytest.fixture
-def cassette_path(tmp_path: object) -> str:
+def cassette_path(tmp_path: Path) -> str:
     return os.path.join(str(tmp_path), "httpx2_test.yaml")
 
 

--- a/tests/test_intercept_pyreqwest.py
+++ b/tests/test_intercept_pyreqwest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pyreqwest_impersonate as pri
@@ -31,7 +32,7 @@ def _preload_cassette(path: str) -> None:
     c.save(path)
 
 
-def test_interceptor_replay(tmp_path: object) -> None:
+def test_interceptor_replay(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -42,7 +43,7 @@ def test_interceptor_replay(tmp_path: object) -> None:
         assert response.json() == {"data": "hello"}
 
 
-def test_interceptor_replay_via_request_method(tmp_path: object) -> None:
+def test_interceptor_replay_via_request_method(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -53,7 +54,7 @@ def test_interceptor_replay_via_request_method(tmp_path: object) -> None:
         assert response.json() == {"data": "hello"}
 
 
-def test_interceptor_no_match_cant_record(tmp_path: object) -> None:
+def test_interceptor_no_match_cant_record(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -146,7 +147,7 @@ def test_build_replay_response_none_body() -> None:
     assert resp.content == b""
 
 
-def test_record_uses_request_url_not_response_url(tmp_path: object) -> None:
+def test_record_uses_request_url_not_response_url(tmp_path: Path) -> None:
     """Recording must store the request URL: responses carry post-redirect URLs
     that would never match on replay."""
 

--- a/tests/test_intercept_requests.py
+++ b/tests/test_intercept_requests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 import requests
@@ -33,7 +34,7 @@ def _preload_cassette(path: str) -> Cassette:
     return cassette
 
 
-def test_requests_interceptor_replay(tmp_path: object) -> None:
+def test_requests_interceptor_replay(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -43,7 +44,7 @@ def test_requests_interceptor_replay(tmp_path: object) -> None:
         assert response.json() == {"data": "hello"}
 
 
-def test_requests_interceptor_record(tmp_path: object, monkeypatch: object) -> None:
+def test_requests_interceptor_record(tmp_path: Path, monkeypatch: object) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
 
     fake_response = requests.Response()
@@ -87,7 +88,7 @@ def test_extract_headers_dict() -> None:
     assert result == {"content-type": ["application/json"], "accept": ["text/html"]}
 
 
-def test_requests_interceptor_no_match(tmp_path: object) -> None:
+def test_requests_interceptor_no_match(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 

--- a/tests/test_intercept_urllib3.py
+++ b/tests/test_intercept_urllib3.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,7 +36,7 @@ def _preload_cassette(path: str) -> None:
     c.save(path)
 
 
-def test_replay_via_urllib3(tmp_path: object) -> None:
+def test_replay_via_urllib3(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -46,7 +47,7 @@ def test_replay_via_urllib3(tmp_path: object) -> None:
         assert response.json() == {"data": "hello"}
 
 
-def test_replay_via_requests(tmp_path: object) -> None:
+def test_replay_via_requests(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -56,7 +57,7 @@ def test_replay_via_requests(tmp_path: object) -> None:
         assert response.json() == {"data": "hello"}
 
 
-def test_replay_with_mismatched_content_length(tmp_path: object) -> None:
+def test_replay_with_mismatched_content_length(tmp_path: Path) -> None:
     """Replaying a cassette whose stored content-length differs from the re-serialized body must not raise."""
     path = os.path.join(str(tmp_path), "test.yaml")
     c = RustCassette()
@@ -81,7 +82,7 @@ def test_replay_with_mismatched_content_length(tmp_path: object) -> None:
         assert body["output"]["message"]["content"][0]["text"] == "hi"
 
 
-def test_record_urllib3(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_record_urllib3(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
 
     fake_response = urllib3.response.HTTPResponse(
@@ -107,7 +108,7 @@ def test_record_urllib3(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.undo()
 
 
-def test_no_match_raises_error(tmp_path: object) -> None:
+def test_no_match_raises_error(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "test.yaml")
     _preload_cassette(path)
 
@@ -256,7 +257,7 @@ def test_build_urllib3_response_headers() -> None:
     assert response.headers.getlist("x-custom") == ["a", "b"]
 
 
-def test_record_urllib3_rewrites_content_length(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_record_urllib3_rewrites_content_length(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A recorded response carrying content-length has it rewritten to the stored body length."""
     path = os.path.join(str(tmp_path), "clen.yaml")
     body = b'{"recorded": true}'

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from collections import Counter
+from pathlib import Path
 
 from cassetter import RecordedRequest
 from cassetter._core import Body, Cassette as RustCassette, HttpInteraction, HttpRequest, HttpResponse
@@ -10,7 +11,7 @@ from cassetter.cassette import Cassette
 from cassetter.recording import RecordMode
 
 
-def _make_cassette(tmp_path: object) -> Cassette:
+def _make_cassette(tmp_path: Path) -> Cassette:
     path = os.path.join(str(tmp_path), "introspection.yaml")
     inner = RustCassette()
     inner.add_interaction(
@@ -38,7 +39,7 @@ def _make_cassette(tmp_path: object) -> Cassette:
     return cassette
 
 
-def test_requests_exposes_vcr_attributes(tmp_path: object) -> None:
+def test_requests_exposes_vcr_attributes(tmp_path: Path) -> None:
     cassette = _make_cassette(tmp_path)
     requests = cassette.requests
 
@@ -62,7 +63,7 @@ def test_requests_exposes_vcr_attributes(tmp_path: object) -> None:
     assert second.query == []
 
 
-def test_request_body_wire_forms(tmp_path: object) -> None:
+def test_request_body_wire_forms(tmp_path: Path) -> None:
     path = os.path.join(str(tmp_path), "bodies.yaml")
     inner = RustCassette()
     for body in (Body("binary", b"\x00\x01"), Body("none")):
@@ -81,7 +82,7 @@ def test_request_body_wire_forms(tmp_path: object) -> None:
     assert cassette.requests[1].body is None
 
 
-def test_play_count_lifecycle(tmp_path: object) -> None:
+def test_play_count_lifecycle(tmp_path: Path) -> None:
     cassette = _make_cassette(tmp_path)
 
     assert cassette.play_count == 0
@@ -108,7 +109,7 @@ def test_introspection_before_load() -> None:
     assert cassette.all_played
 
 
-def test_play_counts_track_repeats(tmp_path: object) -> None:
+def test_play_counts_track_repeats(tmp_path: Path) -> None:
     """Replaying the same interaction twice (matcher fallback) counts both plays."""
     path = os.path.join(str(tmp_path), "repeats.yaml")
     inner = RustCassette()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -29,7 +29,7 @@ def test_configure_registers_marker() -> None:
     config.addinivalue_line.assert_called_once()
 
 
-def test_check_orphans_finds_orphaned_files(tmp_path: object) -> None:
+def test_check_orphans_finds_orphaned_files(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     Path(os.path.join(cassette_dir, "used.yaml")).write_text("---")
     Path(os.path.join(cassette_dir, "orphan.yaml")).write_text("---")
@@ -43,7 +43,7 @@ def test_check_orphans_finds_orphaned_files(tmp_path: object) -> None:
     assert "used.yaml" not in orphans
 
 
-def test_check_orphans_no_orphans(tmp_path: object) -> None:
+def test_check_orphans_no_orphans(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     Path(os.path.join(cassette_dir, "used.yaml")).write_text("---")
 
@@ -53,7 +53,7 @@ def test_check_orphans_no_orphans(tmp_path: object) -> None:
     assert orphans == []
 
 
-def test_check_orphans_ignores_non_yaml_files(tmp_path: object) -> None:
+def test_check_orphans_ignores_non_yaml_files(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     Path(os.path.join(cassette_dir, "readme.txt")).write_text("not a cassette")
     Path(os.path.join(cassette_dir, "data.json")).write_text("{}")
@@ -78,7 +78,7 @@ def test_session_finish_no_orphan_dir() -> None:
     session_finish(session)
 
 
-def test_session_finish_warns_on_orphans(tmp_path: object) -> None:
+def test_session_finish_warns_on_orphans(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     Path(os.path.join(cassette_dir, "orphan.yaml")).write_text("---")
 
@@ -91,7 +91,7 @@ def test_session_finish_warns_on_orphans(tmp_path: object) -> None:
         session_finish(session)
 
 
-def test_session_finish_no_warning_when_no_orphans(tmp_path: object) -> None:
+def test_session_finish_no_warning_when_no_orphans(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     yaml_path = os.path.join(cassette_dir, "used.yaml")
     Path(yaml_path).write_text("---")
@@ -105,7 +105,7 @@ def test_session_finish_no_warning_when_no_orphans(tmp_path: object) -> None:
     session_finish(session)
 
 
-def test_resolve_cassette_default_config(tmp_path: object) -> None:
+def test_resolve_cassette_default_config(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -146,7 +146,7 @@ def test_resolve_cassette_cli_rewrite_drops_the_cassette(tmp_path: Path) -> None
     assert not yaml_path.exists()
 
 
-def test_resolve_cassette_custom_cassette_name(tmp_path: object) -> None:
+def test_resolve_cassette_custom_cassette_name(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -164,7 +164,7 @@ def test_resolve_cassette_custom_cassette_name(tmp_path: object) -> None:
     assert cassette.path.endswith("custom.yaml")
 
 
-def test_resolve_cassette_marker_kwargs_override(tmp_path: object) -> None:
+def test_resolve_cassette_marker_kwargs_override(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     alt_dir = os.path.join(test_dir, "alt", "test_example")
     os.makedirs(alt_dir, exist_ok=True)
@@ -182,7 +182,7 @@ def test_resolve_cassette_marker_kwargs_override(tmp_path: object) -> None:
     assert "alt" in cassette.path
 
 
-def test_resolve_cassette_cli_record_mode_override(tmp_path: object) -> None:
+def test_resolve_cassette_cli_record_mode_override(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -200,7 +200,7 @@ def test_resolve_cassette_cli_record_mode_override(tmp_path: object) -> None:
     assert cassette.record_mode == RecordMode.NONE
 
 
-def test_resolve_cassette_security_config_from_vcr_config(tmp_path: object) -> None:
+def test_resolve_cassette_security_config_from_vcr_config(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -225,7 +225,7 @@ def test_resolve_cassette_security_config_from_vcr_config(tmp_path: object) -> N
     assert cassette is not None
 
 
-def test_resolve_cassette_max_age_from_vcr_config(tmp_path: object) -> None:
+def test_resolve_cassette_max_age_from_vcr_config(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -251,7 +251,7 @@ def test_resolve_cassette_max_age_from_vcr_config(tmp_path: object) -> None:
         )
 
 
-def test_resolve_cassette_max_age_marker_override(tmp_path: object) -> None:
+def test_resolve_cassette_max_age_marker_override(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -277,7 +277,7 @@ def test_resolve_cassette_max_age_marker_override(tmp_path: object) -> None:
         )
 
 
-def test_resolve_cassette_vcr_cassette_dir_fixture(tmp_path: object) -> None:
+def test_resolve_cassette_vcr_cassette_dir_fixture(tmp_path: Path) -> None:
     cassette_dir = os.path.join(str(tmp_path), "custom_cassettes")
     os.makedirs(cassette_dir, exist_ok=True)
     RustCassette().save(os.path.join(cassette_dir, "test_func.yaml"))
@@ -295,7 +295,7 @@ def test_resolve_cassette_vcr_cassette_dir_fixture(tmp_path: object) -> None:
     assert cassette.path == os.path.join(cassette_dir, "test_func.yaml")
 
 
-def test_resolve_cassette_marker_cassette_dir_overrides_fixture(tmp_path: object) -> None:
+def test_resolve_cassette_marker_cassette_dir_overrides_fixture(tmp_path: Path) -> None:
     marker_dir = os.path.join(str(tmp_path), "marker_dir", "test_example")
     os.makedirs(marker_dir, exist_ok=True)
     RustCassette().save(os.path.join(marker_dir, "test_func.yaml"))
@@ -313,7 +313,7 @@ def test_resolve_cassette_marker_cassette_dir_overrides_fixture(tmp_path: object
     assert "marker_dir" in cassette.path
 
 
-def test_resolve_cassette_filter_query_parameters(tmp_path: object) -> None:
+def test_resolve_cassette_filter_query_parameters(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -335,7 +335,7 @@ def test_resolve_cassette_filter_query_parameters(tmp_path: object) -> None:
     assert cassette is not None
 
 
-def test_resolve_cassette_from_cassetter(tmp_path: object) -> None:
+def test_resolve_cassette_from_cassetter(tmp_path: Path) -> None:
     library_dir = os.path.join(str(tmp_path), "shared_cassettes")
     os.makedirs(library_dir, exist_ok=True)
     RustCassette().save(os.path.join(library_dir, "test_func.yaml"))
@@ -353,7 +353,7 @@ def test_resolve_cassette_from_cassetter(tmp_path: object) -> None:
     assert cassette.path == os.path.join(library_dir, "test_func.yaml")
 
 
-def test_resolve_cassette_from_cassetter_defaults_to_none_record_mode(tmp_path: object) -> None:
+def test_resolve_cassette_from_cassetter_defaults_to_none_record_mode(tmp_path: Path) -> None:
     """An unset record mode means `none` under pytest, even though `use_cassette` defaults to `once`."""
     cassette_dir = os.path.join(str(tmp_path), "cassettes")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -372,7 +372,7 @@ def test_resolve_cassette_from_cassetter_defaults_to_none_record_mode(tmp_path: 
     assert cassette.record_mode == RecordMode.NONE
 
 
-def test_resolve_cassette_marker_dir_overrides_cassette_library_dir(tmp_path: object) -> None:
+def test_resolve_cassette_marker_dir_overrides_cassette_library_dir(tmp_path: Path) -> None:
     marker_dir = os.path.join(str(tmp_path), "marker_dir", "test_example")
     os.makedirs(marker_dir, exist_ok=True)
     RustCassette().save(os.path.join(marker_dir, "test_func.yaml"))
@@ -389,7 +389,7 @@ def test_resolve_cassette_marker_dir_overrides_cassette_library_dir(tmp_path: ob
     assert cassette.path == os.path.join(marker_dir, "test_func.yaml")
 
 
-def test_resolve_cassette_ini_on_expiry(tmp_path: object) -> None:
+def test_resolve_cassette_ini_on_expiry(tmp_path: Path) -> None:
     cassette_dir = os.path.join(str(tmp_path), "cassettes")
     os.makedirs(cassette_dir, exist_ok=True)
     path = os.path.join(cassette_dir, "test_func.yaml")
@@ -416,7 +416,7 @@ def test_resolve_cassette_ini_on_expiry(tmp_path: object) -> None:
         )
 
 
-def test_resolve_cassette_ignores_unknown_vcr_config_keys(tmp_path: object) -> None:
+def test_resolve_cassette_ignores_unknown_vcr_config_keys(tmp_path: Path) -> None:
     """Keys VCR.py supports but cassetter handles automatically are no-ops, not errors."""
     cassette_dir = os.path.join(str(tmp_path), "cassettes")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -449,13 +449,13 @@ def test_ini_options_registered() -> None:
     assert ini_names == ["vcr_max_age", "vcr_on_expiry"]
 
 
-def test_check_orphans_includes_toml(tmp_path: object) -> None:
+def test_check_orphans_includes_toml(tmp_path: Path) -> None:
     cassette_dir = str(tmp_path)
     Path(os.path.join(cassette_dir, "orphan.toml")).write_text("---")
     assert check_orphans(cassette_dir, set()) == ["orphan.toml"]
 
 
-def test_resolve_cassette_sanitizes_forbidden_filename_chars(tmp_path: object) -> None:
+def test_resolve_cassette_sanitizes_forbidden_filename_chars(tmp_path: Path) -> None:
     """Node names keep pytest-recording's sanitization so vcrpy-recorded cassettes resolve."""
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
@@ -477,7 +477,7 @@ def test_resolve_cassette_sanitizes_forbidden_filename_chars(tmp_path: object) -
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="':' is not a legal file name character")
-def test_resolve_cassette_keeps_existing_unsanitized_name(tmp_path: object) -> None:
+def test_resolve_cassette_keeps_existing_unsanitized_name(tmp_path: Path) -> None:
     """A cassette recorded before names were sanitized keeps replaying."""
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
@@ -498,7 +498,7 @@ def test_resolve_cassette_keeps_existing_unsanitized_name(tmp_path: object) -> N
     assert os.path.exists(cassette.path)
 
 
-def test_resolve_cassette_records_under_sanitized_name_when_neither_exists(tmp_path: object) -> None:
+def test_resolve_cassette_records_under_sanitized_name_when_neither_exists(tmp_path: Path) -> None:
     """With nothing on disk, a new cassette takes the sanitized name."""
     test_dir = str(tmp_path)
 
@@ -514,7 +514,7 @@ def test_resolve_cassette_records_under_sanitized_name_when_neither_exists(tmp_p
     assert os.path.basename(cassette.path) == "test_func[anthropic-claude].yaml"
 
 
-def test_resolve_cassette_passes_uri_normalizer(tmp_path: object) -> None:
+def test_resolve_cassette_passes_uri_normalizer(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
     cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
     os.makedirs(cassette_dir, exist_ok=True)
@@ -560,7 +560,7 @@ def test_worker_ships_loaded_cassettes_to_controller() -> None:
     assert config.workeroutput["vcr_loaded_cassettes"] == ["/cassettes/a.yaml"]
 
 
-def test_controller_aggregates_worker_shards(tmp_path: object) -> None:
+def test_controller_aggregates_worker_shards(tmp_path: Path) -> None:
     """Every worker's cassettes count as used, not just the controller's."""
     cassette_dir = str(tmp_path)
     for name in ("a.yaml", "b.yaml"):


### PR DESCRIPTION
The `tmp_path` fixture was annotated `object` across the test suite, so every use had to go through `str(tmp_path)` with no type checking behind it. It is a `pathlib.Path`; say so.

175 sites across 16 files, plus the `from pathlib import Path` imports that needed adding. No behaviour change - the call sites already passed `str(tmp_path)`, which type checks the same against `Path`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test type annotations for temporary filesystem paths across cassette, interception, concurrency, plugin, and integration coverage.
  * Expanded validation for orphaned files, cassette filename sanitization, URI normalization, recording paths, and worker-shard aggregation.
  * Existing test behavior remains unchanged; coverage now better documents edge cases and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->