### PR TITLE
Give `Cassette` a `__len__`, and correct the migration table

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -40,15 +40,19 @@ $ pytest
 | `vcr.VCR(...)` | [`Cassetter(...)`](tutorial/configuration.md) | Same idea, same `cassette_library_dir`, and it can be returned from `vcr_config` |
 | `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
-| `before_record_request` | `before_record_request` | Same name, same behavior |
-| `before_record_response` | `before_record_response` | Same name, same behavior |
-| `cassette.requests`, `play_count`, `play_counts`, `all_played` | Same names | vcrpy-style introspection on the cassette object |
+| `before_record_request` | `before_record_request` | Same name. Receives a `RawRequest`, and raises `SkipRecording` where VCR.py returns `None`. Runs on live requests only - see below |
+| `before_record_response` | `before_record_response` | Same name. Receives a `RawResponse` dataclass, not the response dict VCR.py passes, so `response['headers']` becomes `response.headers` |
+| `cassette.requests`, `play_count`, `play_counts`, `all_played`, `len(cassette)` | Same names | vcrpy-style introspection on the cassette object |
 | `decode_compressed_response` | automatic | Responses are always decompressed |
 | `filter_post_data_parameters` | `body_scrub_patterns` | Pattern based instead of parameter name based |
 
 ## What is intentionally different
 
 Filtering is **on by default**. VCR.py records `authorization` headers unless you configure `filter_headers` yourself. Cassetter strips the common sensitive headers, query parameters, and body fields without any configuration. If you relied on credentials being in the cassette (for example, asserting on them), you will need to adjust those tests.
+
+`filter_headers`, `filter_query_parameters` and `body_scrub_patterns` **add to** those built-in lists. VCR.py replaces its own, but its defaults are empty, so passing a list there means "filter this" and here means "filter this too". See [Safe by default](tutorial/security.md#customize-the-filters) for how to define a list outright.
+
+`before_record_request` runs on requests as they go out, not on interactions as they are read back. VCR.py applies it in both directions, so a hook that drops a request also drops any matching interaction already recorded in a cassette; under Cassetter that recording survives, and stays unplayable. If you skip a request that older cassettes still contain - an OAuth token exchange, say - delete those interactions when you migrate.
 
 ## Known limitation
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -41,7 +41,7 @@ $ pytest
 | `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
 | `before_record_request` | `before_record_request` | Same name. Receives a `RawRequest`, and raises `SkipRecording` where VCR.py returns `None`. Runs on live requests only - see below |
-| `before_record_response` | `before_record_response` | Same name. Receives a `RawResponse` dataclass, not the response dict VCR.py passes, so `response['headers']` becomes `response.headers` |
+| `before_record_response` | `before_record_response` | Same name. Receives a `RawResponse` dataclass, not the response dict VCR.py passes, so `response['headers']` becomes `response.headers`. Discard a response by raising `SkipRecording`, not by returning `None` |
 | `cassette.requests`, `play_count`, `play_counts`, `all_played`, `len(cassette)` | Same names | vcrpy-style introspection on the cassette object |
 | `decode_compressed_response` | automatic | Responses are always decompressed |
 | `filter_post_data_parameters` | `body_scrub_patterns` | Pattern based instead of parameter name based |

--- a/src/cassetter/cassette.py
+++ b/src/cassetter/cassette.py
@@ -209,6 +209,10 @@ class Cassette:
         """Whether every recorded interaction has been replayed."""
         return all(self.played_indices)
 
+    def __len__(self) -> int:
+        """How many interactions the cassette holds, across every protocol."""
+        return 0 if self._inner is None else len(self._inner)
+
     @property
     def grpc_interactions(self) -> list[GrpcInteraction]:
         if self._inner is None:

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -160,6 +160,24 @@ def test_cassette_can_record() -> None:
     assert Cassette("/tmp/t.yaml", record_mode=RecordMode.NONE).can_record is False
 
 
+def test_cassette_len_counts_every_protocol(tmp_path: Path) -> None:
+    cassette = Cassette(tmp_path / "len.yaml", record_mode=RecordMode.ALL)
+    assert len(cassette) == 0, "an unloaded cassette holds nothing"
+
+    cassette.load()
+    cassette.record(
+        method="GET",
+        uri="https://api.example.com/a",
+        request_headers={},
+        request_body=None,
+        status=200,
+        response_headers={},
+        response_body=b"{}",
+    )
+
+    assert len(cassette) == len(cassette.interactions) == 1
+
+
 def test_cassette_play_before_load() -> None:
     cassette = Cassette("/tmp/test.yaml")
     with pytest.raises(NoMatchError, match="cassette not loaded"):


### PR DESCRIPTION
Two small things the pydantic-ai migration turned up.

### `len(cassette)`

VCR.py cassettes answer `len()`; ours did not, so code that counts interactions had to be rewritten to reach through `.requests`. The Rust cassette already implements it - this just exposes it, counting every protocol, and returning 0 before a load.

### `docs/migration.md` was wrong about the record hooks

The table said both were "same name, same behavior". Neither is:

- `before_record_response` receives a `RawResponse` dataclass, not the dict VCR.py passes. A ported hook doing `response['headers']` raises `TypeError` on the first re-record.
- `before_record_request` receives a `RawRequest` and signals a skip by raising `SkipRecording`, where VCR.py returns `None`.

I wrote a migration plan off that table and then hit the `TypeError` myself, so this is not hypothetical - "same behavior" is exactly the phrase that stops a reader from checking.

Two further differences are now stated up front rather than left to be discovered:

- **Custom filter lists add to the built-ins** here, where VCR.py replaces. Worth spelling out because the two look identical in a diff and behave differently.
- **`before_record_request` runs on live requests only**, not on interactions read back from disk. VCR.py applies it in both directions, so a hook that drops a request also drops any matching interaction already in a cassette. Under Cassetter that recording survives and can never play, which surfaces as a partially-used cassette rather than anything pointing at the hook. It cost a cassette edit during the pydantic-ai migration to work out why.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cassette length support for counting recorded interactions across all supported protocols.
  * Returns zero when the cassette has not been loaded.

* **Documentation**
  * Clarified request and response callback behavior during migration.
  * Documented cassette-specific request objects, live-request limitations, additive filters, and behavior when hooks skip recorded requests.

* **Tests**
  * Added coverage confirming interaction counts after recording and loading HTTP activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->