### PR TITLE
Honor pytest-recording's `default_cassette` marker

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -39,6 +39,7 @@ $ pytest
 | `vcr` fixture | `cassette` fixture | `vcr` still works as an alias |
 | `vcr.VCR(...)` | [`Cassetter(...)`](tutorial/configuration.md) | Same idea, same `cassette_library_dir`, and it can be returned from `vcr_config` |
 | `vcr_cassette_dir` fixture | `vcr_cassette_dir` fixture | Same name, same behavior |
+| `@pytest.mark.default_cassette("name.yaml")` | Same marker, or `@pytest.mark.vcr("name.yaml")` | Both name the cassette; the positional argument wins if a test carries both |
 | `filter_query_parameters` | `filter_query_parameters` | Same name |
 | `before_record_request` | `before_record_request` | Same name. Receives a `RawRequest`, and raises `SkipRecording` where VCR.py returns `None`. Runs on live requests only - see below |
 | `before_record_response` | `before_record_response` | Same name. Receives a `RawResponse` dataclass, not the response dict VCR.py passes, so `response['headers']` becomes `response.headers`. Discard a response by raising `SkipRecording`, not by returning `None` |

--- a/docs/tutorial/pytest.md
+++ b/docs/tutorial/pytest.md
@@ -132,6 +132,17 @@ async def test_special_case():
 
 The first positional argument sets the cassette file name. The keyword arguments `record_mode`, `cassette_dir`, `max_age`, and `on_expiry` override the module configuration.
 
+pytest-recording's `default_cassette` marker names the cassette too, so suites that already use it keep working:
+
+```python
+@pytest.mark.default_cassette("custom_name.yaml")
+@pytest.mark.vcr
+async def test_special_case():
+    ...
+```
+
+The positional argument wins if a test carries both. Either way the name is resolved against the cassette directory, so pass a name rather than a path.
+
 The command line flag `--record-mode` overrides everything.
 
 ## Customize the cassette directory

--- a/src/cassetter/pytest_plugin/fixtures.py
+++ b/src/cassetter/pytest_plugin/fixtures.py
@@ -85,11 +85,17 @@ def _resolve_cassette(
     vcr_cassette_dir: str | None = None,
     ini_max_age: str | None = None,
     ini_on_expiry: str | None = None,
+    default_cassette: str | None = None,
 ) -> tuple[Cassette, list[type[InterceptorProtocol]]]:
     """Resolve cassette configuration and create a Cassette instance."""
     config, config_cassette_dir = _split_config(vcr_config)
 
-    cassette_name = marker_args[0] if marker_args else _sanitized_file_name(node_name)
+    if marker_args:
+        cassette_name = marker_args[0]
+    elif default_cassette is not None:
+        cassette_name = default_cassette
+    else:
+        cassette_name = _sanitized_file_name(node_name)
 
     record_mode = config.record_mode or "none"
     if "record_mode" in marker_kwargs:
@@ -144,6 +150,9 @@ def cassette(
     cls = request.node.cls
     node_name = f"{cls.__name__}.{request.node.name}" if cls else request.node.name
 
+    default_cassette_marker = request.node.get_closest_marker("default_cassette")
+    default_cassette = default_cassette_marker.args[0] if default_cassette_marker else None
+
     cassette, interceptor_classes = _resolve_cassette(
         node_name=node_name,
         marker_args=marker.args,
@@ -154,6 +163,7 @@ def cassette(
         vcr_cassette_dir=vcr_cassette_dir,
         ini_max_age=request.config.getini("vcr_max_age") or None,
         ini_on_expiry=request.config.getini("vcr_on_expiry") or None,
+        default_cassette=default_cassette,
     )
 
     # Track loaded cassette paths for orphan detection

--- a/src/cassetter/pytest_plugin/fixtures.py
+++ b/src/cassetter/pytest_plugin/fixtures.py
@@ -118,7 +118,8 @@ def _resolve_cassette(
     else:  # pragma: no cover - the vcr_cassette_dir fixture always supplies a directory
         cassette_dir = os.path.join(test_dir, "cassettes", test_file.stem)
 
-    if not marker_args:
+    # Only a name derived from the node can be the sanitized form of a legacy one.
+    if not marker_args and default_cassette is None:
         cassette_name = _existing_file_name(cassette_dir, cassette_name, node_name + ".yaml")
 
     resolved = replace(

--- a/src/cassetter/pytest_plugin/markers.py
+++ b/src/cassetter/pytest_plugin/markers.py
@@ -11,4 +11,8 @@ def configure(config: pytest.Config) -> None:
         "markers",
         "vcr(cassette_name, **kwargs): Mark test to use VCR cassette recording/replay.",
     )
+    config.addinivalue_line(
+        "markers",
+        "default_cassette(cassette_name): Name the cassette, as pytest-recording spells it.",
+    )
     loaded_cassettes(config)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,10 +23,13 @@ from cassetter.pytest_plugin.orphans import (
 from cassetter.recording import RecordMode
 
 
-def test_configure_registers_marker() -> None:
+def test_configure_registers_markers() -> None:
+    """Both are registered, so `--strict-markers` accepts a suite that uses either."""
     config = MagicMock()
     configure(config)
-    config.addinivalue_line.assert_called_once()
+
+    registered = [call.args[1].split("(")[0] for call in config.addinivalue_line.call_args_list]
+    assert registered == ["vcr", "default_cassette"]
 
 
 def test_check_orphans_finds_orphaned_files(tmp_path: Path) -> None:
@@ -123,6 +126,39 @@ def test_resolve_cassette_default_config(tmp_path: Path) -> None:
     assert cassette.path.endswith("test_func.yaml")
     assert cassette.record_mode == RecordMode.NONE
     assert len(interceptor_classes) >= 1
+
+
+def test_resolve_cassette_default_cassette_marker_names_the_file(tmp_path: Path) -> None:
+    """pytest-recording spells the cassette name this way, so a migrated suite keeps working."""
+    test_dir = str(tmp_path)
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=CassetteConfig(record_mode="none", cassette_dir="cassettes"),
+        cli_record_mode=None,
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+        default_cassette="list_sets.yaml",
+    )
+
+    assert cassette.path.endswith(os.path.join("cassettes", "test_example", "list_sets.yaml"))
+
+
+def test_resolve_cassette_marker_arg_beats_default_cassette(tmp_path: Path) -> None:
+    test_dir = str(tmp_path)
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=("from_the_marker.yaml",),
+        marker_kwargs={},
+        vcr_config=CassetteConfig(record_mode="none", cassette_dir="cassettes"),
+        cli_record_mode=None,
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+        default_cassette="from_default_cassette.yaml",
+    )
+
+    assert cassette.path.endswith("from_the_marker.yaml")
 
 
 def test_resolve_cassette_cli_rewrite_drops_the_cassette(tmp_path: Path) -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -131,6 +131,9 @@ def test_resolve_cassette_default_config(tmp_path: Path) -> None:
 def test_resolve_cassette_default_cassette_marker_names_the_file(tmp_path: Path) -> None:
     """pytest-recording spells the cassette name this way, so a migrated suite keeps working."""
     test_dir = str(tmp_path)
+    cassette_dir = tmp_path / "cassettes" / "test_example"
+    cassette_dir.mkdir(parents=True)
+    RustCassette().save(str(cassette_dir / "list_sets.yaml"))
 
     cassette, _ = _resolve_cassette(
         node_name="test_func",
@@ -145,8 +148,32 @@ def test_resolve_cassette_default_cassette_marker_names_the_file(tmp_path: Path)
     assert cassette.path.endswith(os.path.join("cassettes", "test_example", "list_sets.yaml"))
 
 
+def test_resolve_cassette_default_cassette_beats_a_node_named_file_on_disk(tmp_path: Path) -> None:
+    """The legacy-name fallback is for names derived from the node, not ones the test asked for."""
+    test_dir = str(tmp_path)
+    cassette_dir = tmp_path / "cassettes" / "test_example"
+    cassette_dir.mkdir(parents=True)
+    RustCassette().save(str(cassette_dir / "test_func.yaml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=CassetteConfig(record_mode="none", cassette_dir="cassettes"),
+        cli_record_mode=None,
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+        default_cassette="shared.yaml",
+    )
+
+    assert cassette.path.endswith("shared.yaml")
+
+
 def test_resolve_cassette_marker_arg_beats_default_cassette(tmp_path: Path) -> None:
     test_dir = str(tmp_path)
+
+    cassette_dir = tmp_path / "cassettes" / "test_example"
+    cassette_dir.mkdir(parents=True)
+    RustCassette().save(str(cassette_dir / "from_the_marker.yaml"))
 
     cassette, _ = _resolve_cassette(
         node_name="test_func",


### PR DESCRIPTION
Closes #90.

`@pytest.mark.default_cassette("list_sets.yaml")` is how pytest-recording names a cassette. Cassetter ignored it, so a migrated test kept the marker and got a cassette named after the test node instead:

```
@pytest.mark.default_cassette("old_style.yaml")   before: tests/cassettes/test_pytest_recording_marker_still_used.yaml
@pytest.mark.vcr                                   after: tests/cassettes/old_style.yaml
```

Nothing failed loudly. pytest emitted an unknown-marker warning, the test passed, and the recording the suite had always used simply stopped being found - so it re-records, or fails with `NoMatchError` and nothing pointing at the cause. `docs/migration.md` promising "your markers keep working" made that worse.

The marker is registered, so `--strict-markers` accepts it too. Where a test carries both, the positional argument to `vcr` wins, since that is cassetter's own spelling and the more specific one.

### Docs

The reporter's actual question was how to name a cassette at all, and neither guide answered it: `docs/tutorial/pytest.md` mentioned the positional argument only in passing, and `docs/migration.md` never mentioned naming. Both now cover it, including that the name resolves against the cassette directory - the reporter had reached for `use_cassette("list_sets.yaml")` inside a marked test, which writes to the working directory because the bare function takes a path, not a name.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `default_cassette` pytest marker to specify a default cassette filename.
  - Explicit cassette names provided with the `vcr` marker take precedence.
  - Cassette names are resolved relative to the configured cassette directory.

- **Documentation**
  - Added migration and tutorial guidance, including marker usage and precedence examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->