### PR TITLE
Add Go WebSocket transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ uv add cassetter
 
 ## Go
 
-Use the Go module when you need HTTP recording through `http.RoundTripper` or gRPC client interceptors:
+Use the Go module when you need HTTP, gRPC, or WebSocket cassette recording:
 
 ```bash
 go get github.com/Kludex/cassetter/go
 ```
 
 It reads and writes the same structured YAML and TOML formats, including VCR.py YAML migration. It supports all four
-gRPC call patterns with YAML cassettes. It also provides `inspect`, `diff`, `scrub`, and `convert` commands. See the
-[Go documentation](go/README.md) for complete examples and record modes.
+gRPC call patterns and WebSocket text and binary messages with YAML cassettes. It also provides `inspect`, `diff`,
+`scrub`, and `convert` commands. See the [Go documentation](go/README.md) for complete examples and record modes.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ ws_interactions:
         offset_ms: 120
 ```
 
-On replay, `recv()` returns recorded frames in order without a real connection, then raises `ConnectionClosedOK` when they're exhausted (like a real connection at end-of-stream). `send()` is a no-op. Both text and binary frames are supported, and both `async with websockets.connect(...)` and `ws = await websockets.connect(...)` work.
+On replay, `recv()` returns recorded frames in order without a real connection, then raises the recorded close status.
+Older cassettes without a close frame use `ConnectionClosedOK`. `send()` is a no-op. Text, binary, and close frames
+are supported, and both `async with websockets.connect(...)` and `ws = await websockets.connect(...)` work.
 
 ## Streaming / SSE support
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -22,7 +22,7 @@ The format fixtures cover:
 - Every body type.
 - Multi-value headers and metadata.
 - Unicode text and nested JSON.
-- HTTP, gRPC, and WebSocket interactions.
+- HTTP, gRPC, and WebSocket interactions, including WebSocket close statuses.
 - YAML and TOML storage.
 - VCR.py status, header, body, and `parsed_body` migration.
 - Empty cassettes.

--- a/conformance/format/all-protocols.json
+++ b/conformance/format/all-protocols.json
@@ -146,6 +146,15 @@
           "direction": "recv",
           "frameType": "binary",
           "offsetMs": 250
+        },
+        {
+          "body": {
+            "content": "03f064656e696564",
+            "type": "binary"
+          },
+          "direction": "recv",
+          "frameType": "close",
+          "offsetMs": 300
         }
       ],
       "headers": {

--- a/conformance/format/all-protocols.yaml
+++ b/conformance/format/all-protocols.yaml
@@ -118,4 +118,10 @@ ws_interactions:
       # binary body would decode to nothing. Cassetter quotes it when writing.
       content: '00010203'
     offset_ms: 250
+  - direction: recv
+    frame_type: close
+    body:
+      type: binary
+      content: 03f064656e696564
+    offset_ms: 300
   recorded_at: '2026-01-05T00:00:00Z'

--- a/crates/cassetter-core/src/security/mod.rs
+++ b/crates/cassetter-core/src/security/mod.rs
@@ -3,7 +3,7 @@ pub mod defaults;
 pub mod headers;
 
 use crate::protocol::grpc::GrpcInteraction;
-use crate::protocol::http::HttpInteraction;
+use crate::protocol::http::{Body, BodyContent, HttpInteraction};
 use crate::protocol::ws::WsInteraction;
 use crate::{CassetteError, Result};
 
@@ -143,6 +143,19 @@ pub fn scrub_ws_interaction(interaction: &WsInteraction, config: &SecurityConfig
         scrubbed.uri = uri;
     }
     for frame in &mut scrubbed.frames {
+        match (frame.frame_type.as_str(), &frame.body.inner) {
+            ("close", BodyContent::Binary(content)) if content.len() >= 2 => {
+                let mut encoded = content[..2].to_vec();
+                let reason = Body::text(String::from_utf8_lossy(&content[2..]).into_owned());
+                let scrubbed_reason = config.scrubber.scrub_body(&reason, &config.replacement);
+                if let BodyContent::Text(value) = scrubbed_reason.inner {
+                    encoded.extend_from_slice(value.as_bytes());
+                    frame.body = Body::binary(encoded);
+                    continue;
+                }
+            }
+            _ => {}
+        }
         frame.body = config.scrubber.scrub_body(&frame.body, &config.replacement);
     }
     scrubbed
@@ -175,7 +188,6 @@ mod tests {
 
     use super::*;
     use crate::protocol::grpc::{GrpcRequest, GrpcResponse};
-    use crate::protocol::http::{Body, BodyContent};
     use crate::protocol::ws::WsFrame;
 
     fn default_config() -> SecurityConfig {
@@ -251,6 +263,12 @@ mod tests {
                     body: Body::binary(vec![1, 2, 3]),
                     offset_ms: 20,
                 },
+                WsFrame {
+                    direction: "recv".to_string(),
+                    frame_type: "close".to_string(),
+                    body: Body::binary(b"\x03\xf0access_token=secret".to_vec()),
+                    offset_ms: 30,
+                },
             ],
             recorded_at: "2026-01-01T00:00:00Z".to_string(),
         };
@@ -279,6 +297,10 @@ mod tests {
             other => panic!("expected text body, got {other:?}"),
         }
         assert_eq!(scrubbed.frames[2].body, interaction.frames[2].body);
+        assert_eq!(
+            scrubbed.frames[3].body,
+            Body::binary(b"\x03\xf0access_token=[FILTERED]".to_vec())
+        );
     }
 
     #[test]

--- a/go/README.md
+++ b/go/README.md
@@ -152,9 +152,9 @@ func TestEvents(t *testing.T) {
 ```
 
 `DialWebSocket` uses [`github.com/coder/websocket`](https://github.com/coder/websocket).
-It records successful text and binary messages until the connection closes. It
-replays received messages in order without opening a network connection. Sent
-messages do not participate in matching, which matches the other SDKs.
+It records successful text and binary messages with the terminal close status.
+It replays received messages in order without opening a network connection.
+Sent messages do not participate in matching, which matches the other SDKs.
 
 WebSocket matching uses the filtered URI. It supports `WithURINormalizer`,
 repeated playback, host bypass options, header filtering, JSON secret scrubbing,

--- a/go/README.md
+++ b/go/README.md
@@ -1,6 +1,6 @@
 # cassetter-go
 
-Record and replay Go HTTP and gRPC requests with the same structured cassette format as
+Record and replay Go HTTP, gRPC, and WebSocket traffic with the same structured cassette format as
 [`cassetter`](https://github.com/Kludex/cassetter).
 
 ## Install
@@ -113,6 +113,55 @@ the same configuration as HTTP recording.
 Use YAML for cassettes that contain gRPC interactions. TOML supports HTTP only.
 Call `NewGRPCRecorder` instead of `NewTestGRPCRecorder` outside a test, then call
 `Transport.Close` to surface incomplete streams and save errors.
+
+## Record and replay WebSockets
+
+```go
+package example_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/Kludex/cassetter/go"
+    "github.com/coder/websocket"
+)
+
+func TestEvents(t *testing.T) {
+    recorder := cassetter.NewTestWebSocketRecorder(
+        t,
+        cassetter.WithPath("testdata/cassettes/events.yaml"),
+    )
+    connection, _, err := recorder.DialWebSocket(
+        context.Background(),
+        "wss://api.example.com/events",
+        nil,
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer connection.Close(websocket.StatusNormalClosure, "")
+
+    if err := connection.Write(context.Background(), websocket.MessageText, []byte("subscribe")); err != nil {
+        t.Fatal(err)
+    }
+    if _, _, err := connection.Read(context.Background()); err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+`DialWebSocket` uses [`github.com/coder/websocket`](https://github.com/coder/websocket).
+It records successful text and binary messages until the connection closes. It
+replays received messages in order without opening a network connection. Sent
+messages do not participate in matching, which matches the other SDKs.
+
+WebSocket matching uses the filtered URI. It supports `WithURINormalizer`,
+repeated playback, host bypass options, header filtering, JSON secret scrubbing,
+and Unicode NFC normalization. Use YAML because TOML supports HTTP only. Always
+close the connection or read through the remote close so save errors are
+reported. Test cleanup reports a connection left open as an incomplete
+recording.
 
 ## Configure HTTP request matching
 
@@ -279,8 +328,8 @@ preserve the source values. TOML supports HTTP interactions only.
 
 ## Scope
 
-The first release supports HTTP through `http.RoundTripper` and gRPC through
-unary and streaming client interceptors. `Load` accepts structured Cassetter
-YAML, VCR.py YAML, and Cassetter TOML. It exposes typed HTTP, gRPC, and WebSocket
-interactions. YAML rewrites preserve unrecognized top-level protocol sections.
-WebSocket recording is planned.
+The first release supports HTTP through `http.RoundTripper`, gRPC through unary
+and streaming client interceptors, and WebSockets through `DialWebSocket`.
+`Load` accepts structured Cassetter YAML, VCR.py YAML, and Cassetter TOML. It
+exposes typed HTTP, gRPC, and WebSocket interactions. YAML rewrites preserve
+unrecognized top-level protocol sections.

--- a/go/README.md
+++ b/go/README.md
@@ -153,8 +153,9 @@ func TestEvents(t *testing.T) {
 
 `DialWebSocket` uses [`github.com/coder/websocket`](https://github.com/coder/websocket).
 It records successful text and binary messages with the terminal close status.
-It replays received messages in order without opening a network connection.
-Sent messages do not participate in matching, which matches the other SDKs.
+It replays received messages, negotiated subprotocols, and close statuses without
+opening a network connection. Sent messages do not participate in matching,
+which matches the other SDKs.
 
 WebSocket matching uses the filtered URI. It supports `WithURINormalizer`,
 repeated playback, host bypass options, header filtering, JSON secret scrubbing,

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/andybalholm/brotli v1.2.3
+	github.com/coder/websocket v1.8.15
 	github.com/klauspost/compress v1.20.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pmezard/go-difflib v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -2,6 +2,8 @@ github.com/andybalholm/brotli v1.2.3 h1:8H1qwOkl2LPfjf3YezB90JnCliZb6SInJ/OJkEbA
 github.com/andybalholm/brotli v1.2.3/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/go/grpc_record.go
+++ b/go/grpc_record.go
@@ -30,6 +30,7 @@ func (t *Transport) recordGRPC(interaction GRPCInteraction, order uint64) (err e
 	output := *t.cassette
 	output.Interactions = orderedRecordings(t.cassette.Interactions, t.orders)
 	output.GRPCInteractions = orderedRecordings(candidateInteractions, candidateOrders)
+	output.WebSocketInteractions = orderedRecordings(t.cassette.WebSocketInteractions, t.webSocketOrders)
 	if saveErr := output.Save(t.config.path); saveErr != nil {
 		t.saveEmpty = false
 		return saveErr

--- a/go/lifecycle.go
+++ b/go/lifecycle.go
@@ -2,48 +2,10 @@ package cassetter
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"sort"
 	"testing"
 )
-
-// ErrIncompleteRecording identifies a response body that was not fully consumed.
-var ErrIncompleteRecording = errors.New("incomplete cassette recording")
-
-// ErrTransportClosed identifies a request sent after Transport.Close.
-var ErrTransportClosed = errors.New("cassetter transport is closed")
-
-// IncompleteRecordingError describes a response that could not be recorded completely.
-type IncompleteRecordingError struct {
-	Method string
-	URI    string
-}
-
-// Error implements error.
-func (e *IncompleteRecordingError) Error() string {
-	return fmt.Sprintf("%s for %s %s", ErrIncompleteRecording, e.Method, e.URI)
-}
-
-// Unwrap allows errors.Is(err, ErrIncompleteRecording).
-func (e *IncompleteRecordingError) Unwrap() error {
-	return ErrIncompleteRecording
-}
-
-// IncompleteGRPCRecordingError describes a gRPC stream that did not finish.
-type IncompleteGRPCRecordingError struct {
-	Method string
-}
-
-// Error implements error.
-func (e *IncompleteGRPCRecordingError) Error() string {
-	return fmt.Sprintf("%s for gRPC method %s", ErrIncompleteRecording, e.Method)
-}
-
-// Unwrap allows errors.Is(err, ErrIncompleteRecording).
-func (e *IncompleteGRPCRecordingError) Unwrap() error {
-	return ErrIncompleteRecording
-}
 
 // Initialize loads the cassette before the first request.
 func (t *Transport) Initialize() error {
@@ -84,6 +46,16 @@ func (t *Transport) Close() error {
 	for _, order := range grpcOrders {
 		err = errors.Join(err, &IncompleteGRPCRecordingError{Method: t.grpcPending[order]})
 	}
+	webSocketOrders := make([]uint64, 0, len(t.webSocketPending))
+	for order := range t.webSocketPending {
+		webSocketOrders = append(webSocketOrders, order)
+	}
+	sort.Slice(webSocketOrders, func(left int, right int) bool {
+		return webSocketOrders[left] < webSocketOrders[right]
+	})
+	for _, order := range webSocketOrders {
+		err = errors.Join(err, &IncompleteWebSocketRecordingError{URI: t.webSocketPending[order]})
+	}
 	if t.saveEmpty {
 		err = errors.Join(err, t.cassette.Save(t.config.path))
 		t.saveEmpty = false
@@ -99,6 +71,17 @@ func NewGRPCRecorder(options ...Option) *Transport {
 
 // NewTestGRPCRecorder creates a gRPC recorder whose lifecycle is managed by a Go test.
 func NewTestGRPCRecorder(tb testing.TB, options ...Option) *Transport {
+	tb.Helper()
+	return NewTestTransport(tb, nil, options...)
+}
+
+// NewWebSocketRecorder creates a transport for WebSocket dialing.
+func NewWebSocketRecorder(options ...Option) *Transport {
+	return NewTransport(nil, options...)
+}
+
+// NewTestWebSocketRecorder creates a WebSocket recorder whose lifecycle is managed by a Go test.
+func NewTestWebSocketRecorder(tb testing.TB, options ...Option) *Transport {
 	tb.Helper()
 	return NewTestTransport(tb, nil, options...)
 }

--- a/go/lifecycle_errors.go
+++ b/go/lifecycle_errors.go
@@ -1,0 +1,58 @@
+package cassetter
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrIncompleteRecording identifies a response body that was not fully consumed.
+var ErrIncompleteRecording = errors.New("incomplete cassette recording")
+
+// ErrTransportClosed identifies a request sent after Transport.Close.
+var ErrTransportClosed = errors.New("cassetter transport is closed")
+
+// IncompleteRecordingError describes a response that could not be recorded completely.
+type IncompleteRecordingError struct {
+	Method string
+	URI    string
+}
+
+// Error implements error.
+func (e *IncompleteRecordingError) Error() string {
+	return fmt.Sprintf("%s for %s %s", ErrIncompleteRecording, e.Method, e.URI)
+}
+
+// Unwrap allows errors.Is(err, ErrIncompleteRecording).
+func (e *IncompleteRecordingError) Unwrap() error {
+	return ErrIncompleteRecording
+}
+
+// IncompleteGRPCRecordingError describes a gRPC stream that did not finish.
+type IncompleteGRPCRecordingError struct {
+	Method string
+}
+
+// Error implements error.
+func (e *IncompleteGRPCRecordingError) Error() string {
+	return fmt.Sprintf("%s for gRPC method %s", ErrIncompleteRecording, e.Method)
+}
+
+// Unwrap allows errors.Is(err, ErrIncompleteRecording).
+func (e *IncompleteGRPCRecordingError) Unwrap() error {
+	return ErrIncompleteRecording
+}
+
+// IncompleteWebSocketRecordingError describes a WebSocket connection that did not close.
+type IncompleteWebSocketRecordingError struct {
+	URI string
+}
+
+// Error implements error.
+func (e *IncompleteWebSocketRecordingError) Error() string {
+	return fmt.Sprintf("%s for WebSocket URI %s", ErrIncompleteRecording, e.URI)
+}
+
+// Unwrap allows errors.Is(err, ErrIncompleteRecording).
+func (e *IncompleteWebSocketRecordingError) Unwrap() error {
+	return ErrIncompleteRecording
+}

--- a/go/scrub.go
+++ b/go/scrub.go
@@ -49,11 +49,16 @@ func (c *Cassette) Scrub(config SecurityConfig) {
 		filterHeaders(interaction.Headers, config.FilterHeaders)
 		interaction.URI = scrubURI(interaction.URI, config.FilterQueryParameters, config.Replacement)
 		for frameIndex := range interaction.Frames {
-			interaction.Frames[frameIndex].Body = scrubBody(
-				interaction.Frames[frameIndex].Body,
-				config.BodyScrubPatterns,
-				config.Replacement,
-			)
+			frame := &interaction.Frames[frameIndex]
+			if frame.FrameType == "close" {
+				frame.Body = scrubWebSocketCloseBody(
+					frame.Body,
+					config.BodyScrubPatterns,
+					config.Replacement,
+				)
+				continue
+			}
+			frame.Body = scrubBody(frame.Body, config.BodyScrubPatterns, config.Replacement)
 		}
 	}
 }

--- a/go/testdata/conformance/README.md
+++ b/go/testdata/conformance/README.md
@@ -22,7 +22,7 @@ The format fixtures cover:
 - Every body type.
 - Multi-value headers and metadata.
 - Unicode text and nested JSON.
-- HTTP, gRPC, and WebSocket interactions.
+- HTTP, gRPC, and WebSocket interactions, including WebSocket close statuses.
 - YAML and TOML storage.
 - VCR.py status, header, body, and `parsed_body` migration.
 - Empty cassettes.

--- a/go/testdata/conformance/format/all-protocols.json
+++ b/go/testdata/conformance/format/all-protocols.json
@@ -146,6 +146,15 @@
           "direction": "recv",
           "frameType": "binary",
           "offsetMs": 250
+        },
+        {
+          "body": {
+            "content": "03f064656e696564",
+            "type": "binary"
+          },
+          "direction": "recv",
+          "frameType": "close",
+          "offsetMs": 300
         }
       ],
       "headers": {

--- a/go/testdata/conformance/format/all-protocols.yaml
+++ b/go/testdata/conformance/format/all-protocols.yaml
@@ -118,4 +118,10 @@ ws_interactions:
       # binary body would decode to nothing. Cassetter quotes it when writing.
       content: '00010203'
     offset_ms: 250
+  - direction: recv
+    frame_type: close
+    body:
+      type: binary
+      content: 03f064656e696564
+    offset_ms: 300
   recorded_at: '2026-01-05T00:00:00Z'

--- a/go/transport.go
+++ b/go/transport.go
@@ -9,28 +9,31 @@ import (
 	"time"
 )
 
-// Transport records and replays HTTP and gRPC exchanges.
+// Transport records and replays HTTP, gRPC, and WebSocket exchanges.
 type Transport struct {
 	base   http.RoundTripper
 	config transportConfig
 
-	initialize  sync.Once
-	initErr     error
-	mu          sync.Mutex
-	cassette    *Cassette
-	played      []bool
-	grpcPlayed  []bool
-	index       map[string][]int
-	orders      []uint64
-	grpcOrders  []uint64
-	nextOrder   uint64
-	canRecord   bool
-	pending     map[uint64]pendingRecording
-	grpcPending map[uint64]string
-	recordErr   error
-	saveEmpty   bool
-	closed      bool
-	closeErr    error
+	initialize       sync.Once
+	initErr          error
+	mu               sync.Mutex
+	cassette         *Cassette
+	played           []bool
+	grpcPlayed       []bool
+	webSocketPlayed  []bool
+	index            map[string][]int
+	orders           []uint64
+	grpcOrders       []uint64
+	webSocketOrders  []uint64
+	nextOrder        uint64
+	canRecord        bool
+	pending          map[uint64]pendingRecording
+	grpcPending      map[uint64]string
+	webSocketPending map[uint64]string
+	recordErr        error
+	saveEmpty        bool
+	closed           bool
+	closeErr         error
 }
 
 type pendingRecording struct {

--- a/go/transport_record.go
+++ b/go/transport_record.go
@@ -18,6 +18,7 @@ func (t *Transport) record(interaction HTTPInteraction, order uint64) error {
 	output := *t.cassette
 	output.Interactions = orderedRecordings(candidateInteractions, candidateOrders)
 	output.GRPCInteractions = orderedRecordings(t.cassette.GRPCInteractions, t.grpcOrders)
+	output.WebSocketInteractions = orderedRecordings(t.cassette.WebSocketInteractions, t.webSocketOrders)
 	if err := output.Save(t.config.path); err != nil {
 		t.saveEmpty = false
 		return err

--- a/go/transport_state.go
+++ b/go/transport_state.go
@@ -67,11 +67,14 @@ func (t *Transport) load() {
 	}
 	t.played = make([]bool, len(t.cassette.Interactions))
 	t.grpcPlayed = make([]bool, len(t.cassette.GRPCInteractions))
+	t.webSocketPlayed = make([]bool, len(t.cassette.WebSocketInteractions))
 	t.orders = make([]uint64, len(t.cassette.Interactions))
 	t.grpcOrders = make([]uint64, len(t.cassette.GRPCInteractions))
+	t.webSocketOrders = make([]uint64, len(t.cassette.WebSocketInteractions))
 	t.index = make(map[string][]int, len(t.cassette.Interactions))
 	t.pending = make(map[uint64]pendingRecording)
 	t.grpcPending = make(map[uint64]string)
+	t.webSocketPending = make(map[uint64]string)
 	for index, interaction := range t.cassette.Interactions {
 		t.orders[index] = uint64(index)
 		if t.usesMethodURIIndex() {
@@ -82,6 +85,9 @@ func (t *Transport) load() {
 	}
 	for index := range t.cassette.GRPCInteractions {
 		t.grpcOrders[index] = uint64(index)
+	}
+	for index := range t.cassette.WebSocketInteractions {
+		t.webSocketOrders[index] = uint64(index)
 	}
 	t.nextOrder = uint64(
 		len(t.cassette.Interactions) + len(t.cassette.GRPCInteractions) + len(t.cassette.WebSocketInteractions),

--- a/go/websocket_bypass_test.go
+++ b/go/websocket_bypass_test.go
@@ -24,7 +24,13 @@ func TestWebSocketTransportBypassesLocalhost(t *testing.T) {
 		defer func() {
 			_ = connection.CloseNow()
 		}()
-		_, _, err = connection.Read(request.Context())
+		messageType, content, err := connection.Read(request.Context())
+		if err == nil {
+			err = connection.Write(request.Context(), messageType, content)
+		}
+		if err == nil {
+			_, _, err = connection.Read(request.Context())
+		}
 		if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
 			err = nil
 		}
@@ -44,6 +50,12 @@ func TestWebSocketTransportBypassesLocalhost(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if err := connection.Write(context.Background(), websocket.MessageText, []byte("bypassed")); err != nil {
+		t.Fatalf("write bypassed WebSocket: %v", err)
+	}
+	if _, content, err := connection.Read(context.Background()); err != nil || string(content) != "bypassed" {
+		t.Fatalf("read bypassed WebSocket = %q, %v", content, err)
 	}
 	if err := recorder.Close(); err != nil {
 		t.Fatalf("close recorder with bypassed connection: %v", err)

--- a/go/websocket_bypass_test.go
+++ b/go/websocket_bypass_test.go
@@ -1,0 +1,60 @@
+package cassetter_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketTransportBypassesLocalhost(t *testing.T) {
+	t.Parallel()
+	serverResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		defer func() {
+			_ = connection.CloseNow()
+		}()
+		_, _, err = connection.Read(request.Context())
+		if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+			err = nil
+		}
+		serverResult <- err
+	}))
+	t.Cleanup(server.Close)
+	path := filepath.Join(t.TempDir(), "bypassed.yaml")
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+		cassetter.WithIgnoreLocalhost(),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		webSocketURL(server),
+		&websocket.DialOptions{HTTPClient: server.Client()},
+	)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder with bypassed connection: %v", err)
+	}
+	if err := connection.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatalf("close bypassed WebSocket: %v", err)
+	}
+	if err := <-serverResult; err != nil {
+		t.Fatalf("WebSocket server: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("bypassed cassette stat error = %v, want not exist", err)
+	}
+}

--- a/go/websocket_close.go
+++ b/go/websocket_close.go
@@ -1,6 +1,7 @@
 package cassetter
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -12,7 +13,10 @@ import (
 func (c *WebSocketConn) appendCloseFrame(err error) {
 	var closeError websocket.CloseError
 	if !errors.As(err, &closeError) {
-		return
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		closeError.Code = websocket.StatusAbnormalClosure
 	}
 	content := make([]byte, 2+len(closeError.Reason))
 	binary.BigEndian.PutUint16(content, uint16(closeError.Code))
@@ -22,13 +26,17 @@ func (c *WebSocketConn) appendCloseFrame(err error) {
 		offset = 0
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.terminal {
+		return
+	}
+	c.terminal = true
 	c.frames = append(c.frames, WebSocketFrame{
 		Direction: "recv",
 		FrameType: "close",
 		Body:      Body{Type: BodyTypeBinary, Content: content},
 		OffsetMS:  uint64(offset),
 	})
-	c.mu.Unlock()
 }
 
 func replayWebSocketClose(frame WebSocketFrame) (websocket.CloseError, error) {

--- a/go/websocket_close.go
+++ b/go/websocket_close.go
@@ -39,6 +39,24 @@ func (c *WebSocketConn) appendCloseFrame(err error) {
 	})
 }
 
+func scrubWebSocketCloseBody(body Body, patterns []string, replacement string) Body {
+	if body.Type != BodyTypeBinary {
+		return body
+	}
+	content, ok := body.Content.([]byte)
+	if !ok || len(content) < 2 {
+		return body
+	}
+	reason := scrubBody(Body{Type: BodyTypeText, Content: string(content[2:])}, patterns, replacement)
+	scrubbedReason, err := bodyBytes(reason)
+	if err != nil {
+		return body
+	}
+	scrubbed := append([]byte(nil), content[:2]...)
+	scrubbed = append(scrubbed, scrubbedReason...)
+	return Body{Type: BodyTypeBinary, Content: scrubbed}
+}
+
 func replayWebSocketClose(frame WebSocketFrame) (websocket.CloseError, error) {
 	if frame.Body.Type != BodyTypeBinary {
 		return websocket.CloseError{}, fmt.Errorf("recorded WebSocket close body has type %q, want binary", frame.Body.Type)

--- a/go/websocket_close.go
+++ b/go/websocket_close.go
@@ -1,0 +1,49 @@
+package cassetter
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func (c *WebSocketConn) appendCloseFrame(err error) {
+	var closeError websocket.CloseError
+	if !errors.As(err, &closeError) {
+		return
+	}
+	content := make([]byte, 2+len(closeError.Reason))
+	binary.BigEndian.PutUint16(content, uint16(closeError.Code))
+	copy(content[2:], closeError.Reason)
+	offset := time.Since(c.startedAt).Milliseconds()
+	if offset < 0 {
+		offset = 0
+	}
+	c.mu.Lock()
+	c.frames = append(c.frames, WebSocketFrame{
+		Direction: "recv",
+		FrameType: "close",
+		Body:      Body{Type: BodyTypeBinary, Content: content},
+		OffsetMS:  uint64(offset),
+	})
+	c.mu.Unlock()
+}
+
+func replayWebSocketClose(frame WebSocketFrame) (websocket.CloseError, error) {
+	if frame.Body.Type != BodyTypeBinary {
+		return websocket.CloseError{}, fmt.Errorf("recorded WebSocket close body has type %q, want binary", frame.Body.Type)
+	}
+	content, err := bodyBytes(frame.Body)
+	if err != nil {
+		return websocket.CloseError{}, fmt.Errorf("decode recorded WebSocket close: %w", err)
+	}
+	if len(content) < 2 {
+		return websocket.CloseError{}, errors.New("recorded WebSocket close body is shorter than its status code")
+	}
+	return websocket.CloseError{
+		Code:   websocket.StatusCode(binary.BigEndian.Uint16(content)),
+		Reason: string(content[2:]),
+	}, nil
+}

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -35,6 +35,9 @@ func (c *WebSocketConn) Read(ctx context.Context) (websocket.MessageType, []byte
 	if c.replay != nil {
 		return c.replay.read(ctx)
 	}
+	if c.transport == nil {
+		return c.live.Read(ctx)
+	}
 	c.readMu.Lock()
 	messageType, content, err := c.live.Read(ctx)
 	if err == nil {
@@ -60,6 +63,9 @@ func (c *WebSocketConn) Reader(ctx context.Context) (websocket.MessageType, io.R
 func (c *WebSocketConn) Write(ctx context.Context, messageType websocket.MessageType, content []byte) error {
 	if c.replay != nil {
 		return c.replay.write(ctx, messageType)
+	}
+	if c.transport == nil {
+		return c.live.Write(ctx, messageType, content)
 	}
 	c.writeMu.Lock()
 	err := c.live.Write(ctx, messageType, content)

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -64,6 +64,9 @@ func (c *WebSocketConn) Reader(ctx context.Context) (websocket.MessageType, io.R
 
 // Write writes one complete WebSocket message.
 func (c *WebSocketConn) Write(ctx context.Context, messageType websocket.MessageType, content []byte) error {
+	if messageType != websocket.MessageText && messageType != websocket.MessageBinary {
+		return errors.New("cassetter: WebSocket message type must be text or binary")
+	}
 	if c.replay != nil {
 		return c.replay.write(ctx, messageType)
 	}
@@ -76,6 +79,10 @@ func (c *WebSocketConn) Write(ctx context.Context, messageType websocket.Message
 		err = c.appendFrame("send", messageType, content)
 	}
 	c.writeMu.Unlock()
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		c.appendCloseFrame(err)
+		return joinWebSocketErrors(err, c.finalize())
+	}
 	return err
 }
 

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -103,8 +103,8 @@ func (c *WebSocketConn) SetReadLimit(limit int64) {
 
 // Subprotocol returns the negotiated subprotocol for a live connection.
 func (c *WebSocketConn) Subprotocol() string {
-	if c.live == nil {
-		return ""
+	if c.replay != nil {
+		return c.replay.subprotocol
 	}
 	return c.live.Subprotocol()
 }

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -26,6 +26,7 @@ type WebSocketConn struct {
 	writeMu   sync.Mutex
 	mu        sync.Mutex
 	frames    []WebSocketFrame
+	terminal  bool
 	finish    sync.Once
 	finishErr error
 }

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -42,6 +42,8 @@ func (c *WebSocketConn) Read(ctx context.Context) (websocket.MessageType, []byte
 	messageType, content, err := c.live.Read(ctx)
 	if err == nil {
 		err = c.appendFrame("recv", messageType, content)
+	} else {
+		c.appendCloseFrame(err)
 	}
 	c.readMu.Unlock()
 	if err != nil {

--- a/go/websocket_conn.go
+++ b/go/websocket_conn.go
@@ -1,0 +1,150 @@
+package cassetter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"golang.org/x/text/unicode/norm"
+)
+
+// WebSocketConn records or replays messages through the coder/websocket API.
+type WebSocketConn struct {
+	live      *websocket.Conn
+	replay    *replayWebSocketConn
+	transport *Transport
+	uri       string
+	headers   map[string][]string
+	startedAt time.Time
+	order     uint64
+
+	readMu    sync.Mutex
+	writeMu   sync.Mutex
+	mu        sync.Mutex
+	frames    []WebSocketFrame
+	finish    sync.Once
+	finishErr error
+}
+
+// Read reads one complete WebSocket message.
+func (c *WebSocketConn) Read(ctx context.Context) (websocket.MessageType, []byte, error) {
+	if c.replay != nil {
+		return c.replay.read(ctx)
+	}
+	c.readMu.Lock()
+	messageType, content, err := c.live.Read(ctx)
+	if err == nil {
+		err = c.appendFrame("recv", messageType, content)
+	}
+	c.readMu.Unlock()
+	if err != nil {
+		return messageType, content, joinWebSocketErrors(err, c.finalize())
+	}
+	return messageType, content, nil
+}
+
+// Reader returns a reader for one complete WebSocket message.
+func (c *WebSocketConn) Reader(ctx context.Context) (websocket.MessageType, io.Reader, error) {
+	messageType, content, err := c.Read(ctx)
+	if err != nil {
+		return messageType, nil, err
+	}
+	return messageType, bytes.NewReader(content), nil
+}
+
+// Write writes one complete WebSocket message.
+func (c *WebSocketConn) Write(ctx context.Context, messageType websocket.MessageType, content []byte) error {
+	if c.replay != nil {
+		return c.replay.write(ctx, messageType)
+	}
+	c.writeMu.Lock()
+	err := c.live.Write(ctx, messageType, content)
+	if err == nil {
+		err = c.appendFrame("send", messageType, content)
+	}
+	c.writeMu.Unlock()
+	return err
+}
+
+// Writer returns a writer that sends one WebSocket message when closed.
+func (c *WebSocketConn) Writer(ctx context.Context, messageType websocket.MessageType) (io.WriteCloser, error) {
+	if messageType != websocket.MessageText && messageType != websocket.MessageBinary {
+		return nil, errors.New("cassetter: WebSocket message type must be text or binary")
+	}
+	return &webSocketMessageWriter{ctx: ctx, connection: c, messageType: messageType}, nil
+}
+
+// Ping sends a ping to a live connection and is a no-op during replay.
+func (c *WebSocketConn) Ping(ctx context.Context) error {
+	if c.replay != nil {
+		return c.replay.ping(ctx)
+	}
+	return c.live.Ping(ctx)
+}
+
+// SetReadLimit sets the maximum size of a message read from a live connection.
+func (c *WebSocketConn) SetReadLimit(limit int64) {
+	if c.live != nil {
+		c.live.SetReadLimit(limit)
+	}
+}
+
+// Subprotocol returns the negotiated subprotocol for a live connection.
+func (c *WebSocketConn) Subprotocol() string {
+	if c.live == nil {
+		return ""
+	}
+	return c.live.Subprotocol()
+}
+
+// Close performs a WebSocket close handshake and saves recorded frames.
+func (c *WebSocketConn) Close(code websocket.StatusCode, reason string) error {
+	if c.replay != nil {
+		return c.replay.close()
+	}
+	return joinWebSocketErrors(c.live.Close(code, reason), c.finalize())
+}
+
+// CloseNow closes immediately and saves recorded frames.
+func (c *WebSocketConn) CloseNow() error {
+	if c.replay != nil {
+		return c.replay.close()
+	}
+	return joinWebSocketErrors(c.live.CloseNow(), c.finalize())
+}
+
+func (c *WebSocketConn) appendFrame(direction string, messageType websocket.MessageType, content []byte) error {
+	frameType, body, err := webSocketFrameBody(messageType, content)
+	if err != nil {
+		return err
+	}
+	offset := time.Since(c.startedAt).Milliseconds()
+	if offset < 0 {
+		offset = 0
+	}
+	c.mu.Lock()
+	c.frames = append(c.frames, WebSocketFrame{
+		Direction: direction,
+		FrameType: frameType,
+		Body:      body,
+		OffsetMS:  uint64(offset),
+	})
+	c.mu.Unlock()
+	return nil
+}
+
+func webSocketFrameBody(messageType websocket.MessageType, content []byte) (string, Body, error) {
+	switch messageType {
+	case websocket.MessageText:
+		value := norm.NFC.String(string(bytes.ToValidUTF8(content, []byte("�"))))
+		return "text", Body{Type: BodyTypeText, Content: value}, nil
+	case websocket.MessageBinary:
+		return "binary", Body{Type: BodyTypeBinary, Content: bytes.Clone(content)}, nil
+	default:
+		return "", Body{}, errors.New("cassetter: WebSocket message type must be text or binary")
+	}
+}

--- a/go/websocket_dial.go
+++ b/go/websocket_dial.go
@@ -49,7 +49,11 @@ func (t *Transport) DialWebSocket(
 			return nil, nil, err
 		}
 		if found {
-			return newReplayWebSocketConn(interaction), replayWebSocketResponse(parsed), nil
+			connection, err := newReplayWebSocketConn(interaction)
+			if err != nil {
+				return nil, nil, err
+			}
+			return connection, replayWebSocketResponse(parsed), nil
 		}
 	}
 	if !t.canRecord {

--- a/go/websocket_dial.go
+++ b/go/websocket_dial.go
@@ -1,0 +1,92 @@
+package cassetter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// DialWebSocket opens or replays a WebSocket connection.
+func (t *Transport) DialWebSocket(
+	ctx context.Context,
+	uri string,
+	options *websocket.DialOptions,
+) (*WebSocketConn, *http.Response, error) {
+	if err := t.Initialize(); err != nil {
+		return nil, nil, err
+	}
+	if err := t.checkOpen(); err != nil {
+		return nil, nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse WebSocket URI: %w", err)
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return nil, nil, fmt.Errorf("cassetter: unsupported WebSocket URI scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return nil, nil, errors.New("cassetter: WebSocket URI host is required")
+	}
+	if t.shouldBypass(parsed) {
+		connection, response, err := websocket.Dial(ctx, uri, options)
+		if err != nil {
+			return nil, response, err
+		}
+		return &WebSocketConn{live: connection}, response, nil
+	}
+	if t.config.mode != RecordModeAll && t.config.mode != RecordModeRewrite {
+		interaction, found, err := t.takeWebSocketMatch(uri)
+		if err != nil {
+			return nil, nil, err
+		}
+		if found {
+			return newReplayWebSocketConn(interaction), replayWebSocketResponse(parsed), nil
+		}
+	}
+	if !t.canRecord {
+		return nil, nil, &NoWebSocketMatchError{URI: uri}
+	}
+	order, err := t.reserveWebSocketRecording(uri)
+	if err != nil {
+		return nil, nil, err
+	}
+	connection, response, err := websocket.Dial(ctx, uri, options)
+	if err != nil {
+		t.finishWebSocketRecording(order, nil)
+		return nil, response, err
+	}
+	var headers http.Header
+	if options != nil {
+		headers = recordHeaders(options.HTTPHeader)
+	}
+	return &WebSocketConn{
+		live:      connection,
+		transport: t,
+		uri:       uri,
+		headers:   headers,
+		startedAt: time.Now(),
+		order:     order,
+	}, response, nil
+}
+
+func replayWebSocketResponse(uri *url.URL) *http.Response {
+	return &http.Response{
+		Status:     "101 Switching Protocols",
+		StatusCode: http.StatusSwitchingProtocols,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    &http.Request{Method: http.MethodGet, URL: uri},
+	}
+}

--- a/go/websocket_dial.go
+++ b/go/websocket_dial.go
@@ -53,7 +53,7 @@ func (t *Transport) DialWebSocket(
 			if err != nil {
 				return nil, nil, err
 			}
-			return connection, replayWebSocketResponse(parsed), nil
+			return connection, replayWebSocketResponse(parsed, connection.Subprotocol()), nil
 		}
 	}
 	if !t.canRecord {
@@ -88,14 +88,18 @@ func (t *Transport) DialWebSocket(
 	}, response, nil
 }
 
-func replayWebSocketResponse(uri *url.URL) *http.Response {
+func replayWebSocketResponse(uri *url.URL, subprotocol string) *http.Response {
+	headers := make(http.Header)
+	if subprotocol != "" {
+		headers.Set("Sec-WebSocket-Protocol", subprotocol)
+	}
 	return &http.Response{
 		Status:     "101 Switching Protocols",
 		StatusCode: http.StatusSwitchingProtocols,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     make(http.Header),
+		Header:     headers,
 		Body:       http.NoBody,
 		Request:    &http.Request{Method: http.MethodGet, URL: uri},
 	}

--- a/go/websocket_dial.go
+++ b/go/websocket_dial.go
@@ -72,6 +72,12 @@ func (t *Transport) DialWebSocket(
 	if options != nil {
 		headers = recordHeaders(options.HTTPHeader)
 	}
+	if subprotocol := connection.Subprotocol(); subprotocol != "" {
+		if headers == nil {
+			headers = make(http.Header)
+		}
+		headers["sec-websocket-protocol"] = []string{subprotocol}
+	}
 	return &WebSocketConn{
 		live:      connection,
 		transport: t,

--- a/go/websocket_empty_test.go
+++ b/go/websocket_empty_test.go
@@ -1,0 +1,66 @@
+package cassetter_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketRecorderPersistsEmptyConnection(t *testing.T) {
+	t.Parallel()
+	serverResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, &websocket.AcceptOptions{Subprotocols: []string{"chat"}})
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		defer func() {
+			_ = connection.CloseNow()
+		}()
+		_, _, err = connection.Read(request.Context())
+		if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+			err = nil
+		}
+		serverResult <- err
+	}))
+	t.Cleanup(server.Close)
+	path := filepath.Join(t.TempDir(), "empty.yaml")
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		webSocketURL(server),
+		&websocket.DialOptions{HTTPClient: server.Client(), Subprotocols: []string{"chat"}},
+	)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if err := connection.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatalf("close WebSocket: %v", err)
+	}
+	if err := <-serverResult; err != nil {
+		t.Fatalf("WebSocket server: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	cassette, err := cassetter.Load(path)
+	if err != nil {
+		t.Fatalf("load cassette: %v", err)
+	}
+	interaction := cassette.WebSocketInteractions[0]
+	if len(interaction.Frames) != 0 {
+		t.Fatalf("recorded frames = %v, want empty", interaction.Frames)
+	}
+	if got := grpcHeaderValues(interaction.Headers, "sec-websocket-protocol"); len(got) != 1 || got[0] != "chat" {
+		t.Fatalf("recorded subprotocol = %v, want chat", got)
+	}
+}

--- a/go/websocket_errors.go
+++ b/go/websocket_errors.go
@@ -1,0 +1,18 @@
+package cassetter
+
+import "fmt"
+
+// NoWebSocketMatchError describes a WebSocket connection with no matching interaction.
+type NoWebSocketMatchError struct {
+	URI string
+}
+
+// Error implements error.
+func (e *NoWebSocketMatchError) Error() string {
+	return fmt.Sprintf("%s for WebSocket URI %s", ErrNoMatch, e.URI)
+}
+
+// Unwrap allows errors.Is(err, ErrNoMatch).
+func (e *NoWebSocketMatchError) Unwrap() error {
+	return ErrNoMatch
+}

--- a/go/websocket_errors_test.go
+++ b/go/websocket_errors_test.go
@@ -1,0 +1,134 @@
+package cassetter_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketTransportReportsNoMatchAndClosedRecorder(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+	)
+	_, _, err := recorder.DialWebSocket(context.Background(), "ws://offline.example/socket", nil)
+	if !errors.Is(err, cassetter.ErrNoMatch) {
+		t.Fatalf("missing interaction error = %v, want ErrNoMatch", err)
+	}
+	var noMatch *cassetter.NoWebSocketMatchError
+	if !errors.As(err, &noMatch) || noMatch.URI != "ws://offline.example/socket" {
+		t.Fatalf("missing interaction error = %v, want typed URI", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	_, _, err = recorder.DialWebSocket(context.Background(), "ws://offline.example/socket", nil)
+	if !errors.Is(err, cassetter.ErrTransportClosed) {
+		t.Fatalf("closed recorder error = %v, want ErrTransportClosed", err)
+	}
+}
+
+func TestWebSocketRecorderReportsIncompleteConnection(t *testing.T) {
+	t.Parallel()
+	server, _ := startWebSocketTestServer(t)
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(filepath.Join(t.TempDir(), "incomplete.yaml")),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		webSocketURL(server),
+		&websocket.DialOptions{HTTPClient: server.Client()},
+	)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	err = recorder.Close()
+	if !errors.Is(err, cassetter.ErrIncompleteRecording) {
+		t.Fatalf("close recorder error = %v, want ErrIncompleteRecording", err)
+	}
+	var incomplete *cassetter.IncompleteWebSocketRecordingError
+	if !errors.As(err, &incomplete) || incomplete.URI != webSocketURL(server) {
+		t.Fatalf("close recorder error = %v, want typed URI", err)
+	}
+	_ = connection.CloseNow()
+}
+
+func TestWebSocketReplayUsesURINormalizerAndValidatesFrames(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "normalized.yaml")
+	cassette := &cassetter.Cassette{
+		Version:      1,
+		Interactions: []cassetter.HTTPInteraction{},
+		WebSocketInteractions: []cassetter.WebSocketInteraction{{
+			URI: "ws://offline.example/sessions/recorded",
+			Frames: []cassetter.WebSocketFrame{{
+				Direction: "recv",
+				FrameType: "unsupported",
+				Body:      cassetter.Body{Type: cassetter.BodyTypeNone},
+			}},
+		}},
+	}
+	if err := cassette.Save(path); err != nil {
+		t.Fatalf("save cassette: %v", err)
+	}
+	recorder := cassetter.NewTestWebSocketRecorder(
+		t,
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+		cassetter.WithURINormalizer(func(uri string) string {
+			prefix, _, _ := strings.Cut(uri, "/sessions/")
+			return prefix + "/sessions/{id}"
+		}),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		"ws://offline.example/sessions/current",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("dial normalized replay: %v", err)
+	}
+	if _, _, err := connection.Read(context.Background()); err == nil {
+		t.Fatal("unsupported recorded frame returned no error")
+	}
+	if _, err := connection.Writer(context.Background(), websocket.MessageType(99)); err == nil {
+		t.Fatal("unsupported writer message type returned no error")
+	}
+}
+
+func TestWebSocketDialRejectsInvalidURI(t *testing.T) {
+	t.Parallel()
+	recorder := cassetter.NewTestWebSocketRecorder(
+		t,
+		cassetter.WithPath(filepath.Join(t.TempDir(), "invalid.yaml")),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+	)
+	for _, uri := range []string{"https://example.com/socket", "ws:///socket", "ws://example.com/%"} {
+		if _, _, err := recorder.DialWebSocket(context.Background(), uri, nil); err == nil {
+			t.Fatalf("invalid WebSocket URI %q returned no error", uri)
+		}
+	}
+}
+
+func TestWebSocketDialHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+	recorder := cassetter.NewTestWebSocketRecorder(
+		t,
+		cassetter.WithPath(filepath.Join(t.TempDir(), "canceled.yaml")),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := recorder.DialWebSocket(ctx, "ws://offline.example/socket", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled dial error = %v, want context canceled", err)
+	}
+}

--- a/go/websocket_exercise_test.go
+++ b/go/websocket_exercise_test.go
@@ -1,0 +1,100 @@
+package cassetter_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+	"golang.org/x/text/unicode/norm"
+)
+
+func exerciseLiveWebSocket(t *testing.T, connection *cassetter.WebSocketConn) {
+	t.Helper()
+	writer, err := connection.Writer(context.Background(), websocket.MessageText)
+	if err != nil {
+		t.Fatalf("create WebSocket writer: %v", err)
+	}
+	if _, err := writer.Write([]byte("cafe\u0301")); err != nil {
+		t.Fatalf("write WebSocket writer: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close WebSocket writer: %v", err)
+	}
+	if _, content, err := connection.Read(context.Background()); err != nil || string(content) != "cafe\u0301" {
+		t.Fatalf("read text echo = %q, %v", content, err)
+	}
+	secret := []byte(`{"access_token":"secret","message":"hello"}`)
+	if err := connection.Write(context.Background(), websocket.MessageText, secret); err != nil {
+		t.Fatalf("write JSON WebSocket message: %v", err)
+	}
+	messageType, reader, err := connection.Reader(context.Background())
+	if err != nil {
+		t.Fatalf("create WebSocket reader: %v", err)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil || messageType != websocket.MessageText || !bytes.Equal(content, secret) {
+		t.Fatalf("read JSON echo = %q, %v", content, err)
+	}
+	binary := []byte{0xff, 0x00, 0x01}
+	if err := connection.Write(context.Background(), websocket.MessageBinary, binary); err != nil {
+		t.Fatalf("write binary WebSocket message: %v", err)
+	}
+	messageType, content, err = connection.Read(context.Background())
+	if err != nil || messageType != websocket.MessageBinary || !bytes.Equal(content, binary) {
+		t.Fatalf("read binary echo = %x, %v", content, err)
+	}
+}
+
+func exerciseReplayWebSocket(t *testing.T, connection *cassetter.WebSocketConn) {
+	t.Helper()
+	for _, outgoing := range []struct {
+		messageType websocket.MessageType
+		content     []byte
+	}{
+		{messageType: websocket.MessageText, content: []byte("ignored")},
+		{messageType: websocket.MessageText, content: []byte("ignored")},
+		{messageType: websocket.MessageBinary, content: []byte("ignored")},
+	} {
+		if err := connection.Write(context.Background(), outgoing.messageType, outgoing.content); err != nil {
+			t.Fatalf("write replay WebSocket: %v", err)
+		}
+	}
+	messageType, content, err := connection.Read(context.Background())
+	if err != nil || messageType != websocket.MessageText || string(content) != "café" {
+		t.Fatalf("first replay message = %q, %v", content, err)
+	}
+	messageType, content, err = connection.Read(context.Background())
+	expected := `{"access_token":"[FILTERED]","message":"hello"}`
+	if err != nil || messageType != websocket.MessageText || string(content) != expected {
+		t.Fatalf("second replay message = %q, %v", content, err)
+	}
+	messageType, content, err = connection.Read(context.Background())
+	if err != nil || messageType != websocket.MessageBinary || !bytes.Equal(content, []byte{0xff, 0x00, 0x01}) {
+		t.Fatalf("third replay message = %x, %v", content, err)
+	}
+}
+
+func assertRecordedWebSocketFrames(t *testing.T, frames []cassetter.WebSocketFrame) {
+	t.Helper()
+	if len(frames) != 6 {
+		t.Fatalf("got %d WebSocket frames, want 6", len(frames))
+	}
+	for index, frame := range frames {
+		expectedDirection := "send"
+		if index%2 == 1 {
+			expectedDirection = "recv"
+		}
+		if frame.Direction != expectedDirection {
+			t.Fatalf("frame %d direction = %q, want %q", index, frame.Direction, expectedDirection)
+		}
+	}
+	if got := frames[0].Body.Content; got != norm.NFC.String("cafe\u0301") {
+		t.Fatalf("recorded normalized text = %q", got)
+	}
+	if got := frames[2].Body.Content; got != `{"access_token":"[FILTERED]","message":"hello"}` {
+		t.Fatalf("recorded scrubbed text = %q", got)
+	}
+}

--- a/go/websocket_finalize.go
+++ b/go/websocket_finalize.go
@@ -1,0 +1,76 @@
+package cassetter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func (c *WebSocketConn) finalize() error {
+	c.finish.Do(func() {
+		if c.transport == nil {
+			return
+		}
+		c.readMu.Lock()
+		c.writeMu.Lock()
+		c.mu.Lock()
+		frames := append([]WebSocketFrame(nil), c.frames...)
+		c.frames = nil
+		c.mu.Unlock()
+		c.writeMu.Unlock()
+		c.readMu.Unlock()
+		if len(frames) == 0 {
+			c.transport.finishWebSocketRecording(c.order, nil)
+			return
+		}
+		c.finishErr = c.transport.recordWebSocket(WebSocketInteraction{
+			URI:        c.uri,
+			Headers:    c.headers,
+			Frames:     frames,
+			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}, c.order)
+	})
+	return c.finishErr
+}
+
+func joinWebSocketErrors(callErr error, recordingErr error) error {
+	if callErr == nil {
+		return recordingErr
+	}
+	if recordingErr == nil {
+		return callErr
+	}
+	return errors.Join(callErr, recordingErr)
+}
+
+type webSocketMessageWriter struct {
+	ctx         context.Context
+	connection  *WebSocketConn
+	messageType websocket.MessageType
+	mu          sync.Mutex
+	content     bytes.Buffer
+	closed      bool
+}
+
+func (w *webSocketMessageWriter) Write(content []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, errors.New("cassetter: WebSocket message writer is closed")
+	}
+	return w.content.Write(content)
+}
+
+func (w *webSocketMessageWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	return w.connection.Write(w.ctx, w.messageType, w.content.Bytes())
+}

--- a/go/websocket_finalize.go
+++ b/go/websocket_finalize.go
@@ -23,10 +23,6 @@ func (c *WebSocketConn) finalize() error {
 		c.mu.Unlock()
 		c.writeMu.Unlock()
 		c.readMu.Unlock()
-		if len(frames) == 0 {
-			c.transport.finishWebSocketRecording(c.order, nil)
-			return
-		}
 		c.finishErr = c.transport.recordWebSocket(WebSocketInteraction{
 			URI:        c.uri,
 			Headers:    c.headers,

--- a/go/websocket_record.go
+++ b/go/websocket_record.go
@@ -1,0 +1,43 @@
+package cassetter
+
+import "errors"
+
+func (t *Transport) recordWebSocket(interaction WebSocketInteraction, order uint64) (err error) {
+	cassette := &Cassette{
+		Version:               1,
+		Interactions:          []HTTPInteraction{},
+		WebSocketInteractions: []WebSocketInteraction{interaction},
+	}
+	cassette.Scrub(t.config.security)
+	interaction = cassette.WebSocketInteractions[0]
+
+	t.mu.Lock()
+	defer func() {
+		delete(t.webSocketPending, order)
+		if err != nil {
+			t.recordErr = errors.Join(t.recordErr, err)
+		}
+		t.mu.Unlock()
+	}()
+	if t.closed {
+		return ErrTransportClosed
+	}
+	candidateInteractions := append([]WebSocketInteraction(nil), t.cassette.WebSocketInteractions...)
+	candidateInteractions = append(candidateInteractions, interaction)
+	candidateOrders := append([]uint64(nil), t.webSocketOrders...)
+	candidateOrders = append(candidateOrders, order)
+
+	output := *t.cassette
+	output.Interactions = orderedRecordings(t.cassette.Interactions, t.orders)
+	output.GRPCInteractions = orderedRecordings(t.cassette.GRPCInteractions, t.grpcOrders)
+	output.WebSocketInteractions = orderedRecordings(candidateInteractions, candidateOrders)
+	if saveErr := output.Save(t.config.path); saveErr != nil {
+		t.saveEmpty = false
+		return saveErr
+	}
+	t.saveEmpty = false
+	t.cassette.WebSocketInteractions = candidateInteractions
+	t.webSocketPlayed = append(t.webSocketPlayed, false)
+	t.webSocketOrders = candidateOrders
+	return nil
+}

--- a/go/websocket_remote_close_test.go
+++ b/go/websocket_remote_close_test.go
@@ -1,0 +1,56 @@
+package cassetter_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		if err := connection.Write(request.Context(), websocket.MessageText, []byte("message")); err != nil {
+			return
+		}
+		_ = connection.Close(websocket.StatusNormalClosure, "done")
+	}))
+	t.Cleanup(server.Close)
+	path := filepath.Join(t.TempDir(), "remote-close.yaml")
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		webSocketURL(server),
+		&websocket.DialOptions{HTTPClient: server.Client()},
+	)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if _, content, err := connection.Read(context.Background()); err != nil || string(content) != "message" {
+		t.Fatalf("read WebSocket message = %q, %v", content, err)
+	}
+	if _, _, err := connection.Read(context.Background()); websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+		t.Fatalf("remote close error = %v, want normal closure", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	cassette, err := cassetter.Load(path)
+	if err != nil {
+		t.Fatalf("load cassette: %v", err)
+	}
+	if got := len(cassette.WebSocketInteractions[0].Frames); got != 1 {
+		t.Fatalf("recorded frames = %d, want 1", got)
+	}
+}

--- a/go/websocket_remote_close_test.go
+++ b/go/websocket_remote_close_test.go
@@ -2,6 +2,7 @@ package cassetter_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -21,7 +22,7 @@ func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
 		if err := connection.Write(request.Context(), websocket.MessageText, []byte("message")); err != nil {
 			return
 		}
-		_ = connection.Close(websocket.StatusNormalClosure, "done")
+		_ = connection.Close(websocket.StatusPolicyViolation, "denied")
 	}))
 	t.Cleanup(server.Close)
 	path := filepath.Join(t.TempDir(), "remote-close.yaml")
@@ -40,8 +41,8 @@ func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
 	if _, content, err := connection.Read(context.Background()); err != nil || string(content) != "message" {
 		t.Fatalf("read WebSocket message = %q, %v", content, err)
 	}
-	if _, _, err := connection.Read(context.Background()); websocket.CloseStatus(err) != websocket.StatusNormalClosure {
-		t.Fatalf("remote close error = %v, want normal closure", err)
+	if _, _, err := connection.Read(context.Background()); websocket.CloseStatus(err) != websocket.StatusPolicyViolation {
+		t.Fatalf("remote close error = %v, want policy violation", err)
 	}
 	if err := recorder.Close(); err != nil {
 		t.Fatalf("close recorder: %v", err)
@@ -50,7 +51,26 @@ func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load cassette: %v", err)
 	}
-	if got := len(cassette.WebSocketInteractions[0].Frames); got != 1 {
-		t.Fatalf("recorded frames = %d, want 1", got)
+	if got := len(cassette.WebSocketInteractions[0].Frames); got != 2 {
+		t.Fatalf("recorded frames = %d, want 2", got)
+	}
+
+	server.Close()
+	replayer := cassetter.NewTestWebSocketRecorder(
+		t,
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+	)
+	replay, _, err := replayer.DialWebSocket(context.Background(), webSocketURL(server), nil)
+	if err != nil {
+		t.Fatalf("dial replay WebSocket: %v", err)
+	}
+	if _, content, err := replay.Read(context.Background()); err != nil || string(content) != "message" {
+		t.Fatalf("read replay message = %q, %v", content, err)
+	}
+	_, _, err = replay.Read(context.Background())
+	var closeError websocket.CloseError
+	if !errors.As(err, &closeError) || closeError.Code != websocket.StatusPolicyViolation || closeError.Reason != "denied" {
+		t.Fatalf("replayed close error = %v, want policy violation denied", err)
 	}
 }

--- a/go/websocket_remote_close_test.go
+++ b/go/websocket_remote_close_test.go
@@ -22,7 +22,7 @@ func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
 		if err := connection.Write(request.Context(), websocket.MessageText, []byte("message")); err != nil {
 			return
 		}
-		_ = connection.Close(websocket.StatusPolicyViolation, "denied")
+		_ = connection.Close(websocket.StatusPolicyViolation, "access_token=secret")
 	}))
 	t.Cleanup(server.Close)
 	path := filepath.Join(t.TempDir(), "remote-close.yaml")
@@ -70,7 +70,8 @@ func TestWebSocketRecorderFinalizesRemoteClose(t *testing.T) {
 	}
 	_, _, err = replay.Read(context.Background())
 	var closeError websocket.CloseError
-	if !errors.As(err, &closeError) || closeError.Code != websocket.StatusPolicyViolation || closeError.Reason != "denied" {
-		t.Fatalf("replayed close error = %v, want policy violation denied", err)
+	if !errors.As(err, &closeError) || closeError.Code != websocket.StatusPolicyViolation ||
+		closeError.Reason != "access_token=[FILTERED]" {
+		t.Fatalf("replayed close error = %v, want filtered policy violation", err)
 	}
 }

--- a/go/websocket_replay.go
+++ b/go/websocket_replay.go
@@ -1,0 +1,87 @@
+package cassetter
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/coder/websocket"
+)
+
+type replayWebSocketConn struct {
+	frames []WebSocketFrame
+	mu     sync.Mutex
+	next   int
+	closed bool
+}
+
+func newReplayWebSocketConn(interaction WebSocketInteraction) *WebSocketConn {
+	frames := make([]WebSocketFrame, 0, len(interaction.Frames))
+	for _, frame := range interaction.Frames {
+		if frame.Direction == "recv" {
+			frames = append(frames, frame)
+		}
+	}
+	return &WebSocketConn{replay: &replayWebSocketConn{frames: frames}}
+}
+
+func (c *replayWebSocketConn) read(ctx context.Context) (websocket.MessageType, []byte, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, nil, err
+	}
+	c.mu.Lock()
+	if c.closed || c.next >= len(c.frames) {
+		c.closed = true
+		c.mu.Unlock()
+		return 0, nil, websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: "cassette replay exhausted"}
+	}
+	frame := c.frames[c.next]
+	c.next++
+	c.mu.Unlock()
+	content, err := bodyBytes(frame.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	switch frame.FrameType {
+	case "text":
+		return websocket.MessageText, content, nil
+	case "binary":
+		return websocket.MessageBinary, content, nil
+	default:
+		return 0, nil, errors.New("recorded WebSocket frame type must be text or binary")
+	}
+}
+
+func (c *replayWebSocketConn) write(ctx context.Context, messageType websocket.MessageType) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if messageType != websocket.MessageText && messageType != websocket.MessageBinary {
+		return errors.New("cassetter: WebSocket message type must be text or binary")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: "cassette replay closed"}
+	}
+	return nil
+}
+
+func (c *replayWebSocketConn) ping(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: "cassette replay closed"}
+	}
+	return nil
+}
+
+func (c *replayWebSocketConn) close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	return nil
+}

--- a/go/websocket_replay.go
+++ b/go/websocket_replay.go
@@ -9,20 +9,31 @@ import (
 )
 
 type replayWebSocketConn struct {
-	frames []WebSocketFrame
-	mu     sync.Mutex
-	next   int
-	closed bool
+	frames   []WebSocketFrame
+	terminal websocket.CloseError
+	mu       sync.Mutex
+	next     int
+	closed   bool
 }
 
-func newReplayWebSocketConn(interaction WebSocketInteraction) *WebSocketConn {
+func newReplayWebSocketConn(interaction WebSocketInteraction) (*WebSocketConn, error) {
 	frames := make([]WebSocketFrame, 0, len(interaction.Frames))
+	terminal := websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: "cassette replay exhausted"}
 	for _, frame := range interaction.Frames {
-		if frame.Direction == "recv" {
-			frames = append(frames, frame)
+		if frame.Direction != "recv" {
+			continue
 		}
+		if frame.FrameType == "close" {
+			var err error
+			terminal, err = replayWebSocketClose(frame)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		frames = append(frames, frame)
 	}
-	return &WebSocketConn{replay: &replayWebSocketConn{frames: frames}}
+	return &WebSocketConn{replay: &replayWebSocketConn{frames: frames, terminal: terminal}}, nil
 }
 
 func (c *replayWebSocketConn) read(ctx context.Context) (websocket.MessageType, []byte, error) {
@@ -33,7 +44,7 @@ func (c *replayWebSocketConn) read(ctx context.Context) (websocket.MessageType, 
 	if c.closed || c.next >= len(c.frames) {
 		c.closed = true
 		c.mu.Unlock()
-		return 0, nil, websocket.CloseError{Code: websocket.StatusNormalClosure, Reason: "cassette replay exhausted"}
+		return 0, nil, c.terminal
 	}
 	frame := c.frames[c.next]
 	c.next++

--- a/go/websocket_replay.go
+++ b/go/websocket_replay.go
@@ -9,11 +9,12 @@ import (
 )
 
 type replayWebSocketConn struct {
-	frames   []WebSocketFrame
-	terminal websocket.CloseError
-	mu       sync.Mutex
-	next     int
-	closed   bool
+	frames      []WebSocketFrame
+	terminal    websocket.CloseError
+	subprotocol string
+	mu          sync.Mutex
+	next        int
+	closed      bool
 }
 
 func newReplayWebSocketConn(interaction WebSocketInteraction) (*WebSocketConn, error) {
@@ -33,7 +34,13 @@ func newReplayWebSocketConn(interaction WebSocketInteraction) (*WebSocketConn, e
 		}
 		frames = append(frames, frame)
 	}
-	return &WebSocketConn{replay: &replayWebSocketConn{frames: frames, terminal: terminal}}, nil
+	subprotocol := ""
+	if values, found := findHeader(interaction.Headers, "sec-websocket-protocol"); found && len(values) > 0 {
+		subprotocol = values[0]
+	}
+	return &WebSocketConn{
+		replay: &replayWebSocketConn{frames: frames, terminal: terminal, subprotocol: subprotocol},
+	}, nil
 }
 
 func (c *replayWebSocketConn) read(ctx context.Context) (websocket.MessageType, []byte, error) {

--- a/go/websocket_state.go
+++ b/go/websocket_state.go
@@ -1,0 +1,58 @@
+package cassetter
+
+import "errors"
+
+func (t *Transport) takeWebSocketMatch(uri string) (WebSocketInteraction, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return WebSocketInteraction{}, false, ErrTransportClosed
+	}
+	probe := t.matchingWebSocketURI(uri)
+	fallback := -1
+	for index, interaction := range t.cassette.WebSocketInteractions {
+		if t.matchingWebSocketURI(interaction.URI) != probe {
+			continue
+		}
+		if !t.webSocketPlayed[index] {
+			t.webSocketPlayed[index] = true
+			return interaction, true, nil
+		}
+		if fallback < 0 {
+			fallback = index
+		}
+	}
+	if fallback >= 0 {
+		return t.cassette.WebSocketInteractions[fallback], true, nil
+	}
+	return WebSocketInteraction{}, false, nil
+}
+
+func (t *Transport) matchingWebSocketURI(uri string) string {
+	uri = scrubURI(uri, t.config.security.FilterQueryParameters, t.config.security.Replacement)
+	if t.config.uriNormalizer != nil {
+		return t.config.uriNormalizer(uri)
+	}
+	return uri
+}
+
+func (t *Transport) reserveWebSocketRecording(uri string) (uint64, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return 0, ErrTransportClosed
+	}
+	order := t.nextOrder
+	t.nextOrder++
+	t.webSocketPending[order] = uri
+	return order, nil
+}
+
+func (t *Transport) finishWebSocketRecording(order uint64, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.webSocketPending, order)
+	if err != nil {
+		t.recordErr = errors.Join(t.recordErr, err)
+	}
+}

--- a/go/websocket_test_server_test.go
+++ b/go/websocket_test_server_test.go
@@ -1,0 +1,48 @@
+package cassetter_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coder/websocket"
+)
+
+func startWebSocketTestServer(t *testing.T) (*httptest.Server, <-chan error) {
+	t.Helper()
+	result := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, &websocket.AcceptOptions{Subprotocols: []string{"chat"}})
+		if err != nil {
+			result <- err
+			return
+		}
+		defer func() {
+			_ = connection.CloseNow()
+		}()
+		for range 3 {
+			messageType, content, err := connection.Read(request.Context())
+			if err != nil {
+				result <- err
+				return
+			}
+			if err := connection.Write(request.Context(), messageType, content); err != nil {
+				result <- err
+				return
+			}
+		}
+		_, _, err = connection.Read(request.Context())
+		if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+			result <- errors.New("WebSocket client did not close normally")
+			return
+		}
+		result <- nil
+	}))
+	t.Cleanup(server.Close)
+	return server, result
+}
+
+func webSocketURL(server *httptest.Server) string {
+	return "ws" + server.URL[len("http"):]
+}

--- a/go/websocket_transport_test.go
+++ b/go/websocket_transport_test.go
@@ -84,6 +84,9 @@ func TestWebSocketTransportRecordsAndReplaysMessages(t *testing.T) {
 	if got := replay.Subprotocol(); got != "chat" {
 		t.Fatalf("replay subprotocol = %q, want chat", got)
 	}
+	if got := replayResponse.Header.Get("Sec-WebSocket-Protocol"); got != "chat" {
+		t.Fatalf("replay response subprotocol = %q, want chat", got)
+	}
 	if err := replay.Ping(context.Background()); err != nil {
 		t.Fatalf("ping replay WebSocket: %v", err)
 	}

--- a/go/websocket_transport_test.go
+++ b/go/websocket_transport_test.go
@@ -1,0 +1,102 @@
+package cassetter_test
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketTransportRecordsAndReplaysMessages(t *testing.T) {
+	t.Parallel()
+	server, serverResult := startWebSocketTestServer(t)
+	path := filepath.Join(t.TempDir(), "websocket.yaml")
+	uri := webSocketURL(server) + "/stream?token=secret"
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	options := &websocket.DialOptions{
+		HTTPClient:   server.Client(),
+		HTTPHeader:   http.Header{"Authorization": {"secret"}, "X-Request": {"request"}},
+		Subprotocols: []string{"chat"},
+	}
+	connection, response, err := recorder.DialWebSocket(context.Background(), uri, options)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	if response == nil || response.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("handshake response = %v, want switching protocols", response)
+	}
+	connection.SetReadLimit(1024)
+	if got := connection.Subprotocol(); got != "chat" {
+		t.Fatalf("subprotocol = %q, want chat", got)
+	}
+	exerciseLiveWebSocket(t, connection)
+	if err := connection.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatalf("close WebSocket: %v", err)
+	}
+	if err := <-serverResult; err != nil {
+		t.Fatalf("WebSocket server: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+
+	cassette, err := cassetter.Load(path)
+	if err != nil {
+		t.Fatalf("load cassette: %v", err)
+	}
+	if len(cassette.WebSocketInteractions) != 1 {
+		t.Fatalf("got %d WebSocket interactions, want 1", len(cassette.WebSocketInteractions))
+	}
+	interaction := cassette.WebSocketInteractions[0]
+	if interaction.URI != webSocketURL(server)+"/stream?token=[FILTERED]" {
+		t.Fatalf("recorded URI = %q", interaction.URI)
+	}
+	if got := grpcHeaderValues(interaction.Headers, "authorization"); len(got) != 0 {
+		t.Fatalf("recorded authorization header = %v", got)
+	}
+	if got := grpcHeaderValues(interaction.Headers, "x-request"); len(got) != 1 || got[0] != "request" {
+		t.Fatalf("recorded x-request header = %v", got)
+	}
+	assertRecordedWebSocketFrames(t, interaction.Frames)
+
+	server.Close()
+	replayer := cassetter.NewTestWebSocketRecorder(
+		t,
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeNone),
+	)
+	replay, replayResponse, err := replayer.DialWebSocket(context.Background(), uri, nil)
+	if err != nil {
+		t.Fatalf("dial replay WebSocket: %v", err)
+	}
+	if replayResponse == nil || replayResponse.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("replay handshake response = %v, want switching protocols", replayResponse)
+	}
+	if err := replay.Ping(context.Background()); err != nil {
+		t.Fatalf("ping replay WebSocket: %v", err)
+	}
+	exerciseReplayWebSocket(t, replay)
+	_, _, err = replay.Read(context.Background())
+	if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+		t.Fatalf("exhausted replay error = %v, want normal closure", err)
+	}
+	if err := replay.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatalf("close replay WebSocket: %v", err)
+	}
+	repeated, _, err := replayer.DialWebSocket(context.Background(), uri, nil)
+	if err != nil {
+		t.Fatalf("dial repeated replay WebSocket: %v", err)
+	}
+	if _, content, err := repeated.Read(context.Background()); err != nil || string(content) != "café" {
+		t.Fatalf("repeated replay message = %q, %v", content, err)
+	}
+	if err := repeated.CloseNow(); err != nil {
+		t.Fatalf("close repeated replay WebSocket: %v", err)
+	}
+}

--- a/go/websocket_transport_test.go
+++ b/go/websocket_transport_test.go
@@ -63,6 +63,9 @@ func TestWebSocketTransportRecordsAndReplaysMessages(t *testing.T) {
 	if got := grpcHeaderValues(interaction.Headers, "x-request"); len(got) != 1 || got[0] != "request" {
 		t.Fatalf("recorded x-request header = %v", got)
 	}
+	if got := grpcHeaderValues(interaction.Headers, "sec-websocket-protocol"); len(got) != 1 || got[0] != "chat" {
+		t.Fatalf("recorded subprotocol = %v, want chat", got)
+	}
 	assertRecordedWebSocketFrames(t, interaction.Frames)
 
 	server.Close()
@@ -77,6 +80,9 @@ func TestWebSocketTransportRecordsAndReplaysMessages(t *testing.T) {
 	}
 	if replayResponse == nil || replayResponse.StatusCode != http.StatusSwitchingProtocols {
 		t.Fatalf("replay handshake response = %v, want switching protocols", replayResponse)
+	}
+	if got := replay.Subprotocol(); got != "chat" {
+		t.Fatalf("replay subprotocol = %q, want chat", got)
 	}
 	if err := replay.Ping(context.Background()); err != nil {
 		t.Fatalf("ping replay WebSocket: %v", err)

--- a/go/websocket_write_error_test.go
+++ b/go/websocket_write_error_test.go
@@ -1,0 +1,61 @@
+package cassetter_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+	"github.com/coder/websocket"
+)
+
+func TestWebSocketRecorderFinalizesTerminalWriteError(t *testing.T) {
+	t.Parallel()
+	serverClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			return
+		}
+		_ = connection.CloseNow()
+		close(serverClosed)
+	}))
+	t.Cleanup(server.Close)
+	path := filepath.Join(t.TempDir(), "write-error.yaml")
+	recorder := cassetter.NewWebSocketRecorder(
+		cassetter.WithPath(path),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	connection, _, err := recorder.DialWebSocket(
+		context.Background(),
+		webSocketURL(server),
+		&websocket.DialOptions{HTTPClient: server.Client()},
+	)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	<-serverClosed
+	var writeErr error
+	for range 10 {
+		writeErr = connection.Write(context.Background(), websocket.MessageText, make([]byte, 64*1024))
+		if writeErr != nil {
+			break
+		}
+	}
+	if writeErr == nil {
+		t.Fatal("writes to closed WebSocket returned no error")
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	cassette, err := cassetter.Load(path)
+	if err != nil {
+		t.Fatalf("load cassette: %v", err)
+	}
+	frames := cassette.WebSocketInteractions[0].Frames
+	if len(frames) == 0 || frames[len(frames)-1].FrameType != "close" {
+		t.Fatalf("recorded frames = %v, want terminal close", frames)
+	}
+}

--- a/src/cassetter/_core.pyi
+++ b/src/cassetter/_core.pyi
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 BodyType = Literal["json", "text", "binary", "none"]
-FrameType = Literal["text", "binary"]
+FrameType = Literal["text", "binary", "close"]
 Direction = Literal["send", "recv"]
 Matcher = Literal["method", "uri", "headers", "body", "json_body"]
 

--- a/src/cassetter/intercept/_websockets.py
+++ b/src/cassetter/intercept/_websockets.py
@@ -33,6 +33,7 @@ class VCRWebSocket:
         self.subprotocol = subprotocol
         self._frames: list[WsFrame] = []
         self._terminal_recorded = False
+        self._flushed = False
         self._start_time = time.monotonic()
 
     async def send(self, message: str | bytes) -> None:
@@ -50,10 +51,10 @@ class VCRWebSocket:
         except websockets.exceptions.ConnectionClosed as exc:
             if not self._terminal_recorded:
                 self._terminal_recorded = True
-                if exc.rcvd is not None:
-                    content = struct.pack(">H", exc.rcvd.code) + exc.rcvd.reason.encode()
-                    offset_ms = int((time.monotonic() - self._start_time) * 1000)
-                    self._frames.append(WsFrame("recv", "close", Body("binary", content), offset_ms))
+                close = exc.rcvd or Close(1006, "")
+                content = struct.pack(">H", close.code) + close.reason.encode()
+                offset_ms = int((time.monotonic() - self._start_time) * 1000)
+                self._frames.append(WsFrame("recv", "close", Body("binary", content), offset_ms))
                 self._flush()
             raise
         offset_ms = int((time.monotonic() - self._start_time) * 1000)
@@ -70,9 +71,10 @@ class VCRWebSocket:
 
     def _flush(self) -> None:
         cassette = get_current_cassette()
-        if self._frames and cassette is not None:
+        if not self._flushed and cassette is not None:
             cassette.record_ws(self._uri, self._headers, self._frames)
             self._frames = []
+            self._flushed = True
 
     async def __aenter__(self) -> VCRWebSocket:
         return self

--- a/src/cassetter/intercept/_websockets.py
+++ b/src/cassetter/intercept/_websockets.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import struct
 import time
 from collections.abc import AsyncIterator, Generator
 from typing import Any
 
 import websockets
 import websockets.asyncio.client
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.frames import Close
 
 from cassetter._core import Body, WsFrame, WsInteraction
 from cassetter._state import get_current_cassette
@@ -33,7 +35,15 @@ class VCRWebSocket:
         await self._real.send(message)
 
     async def recv(self) -> str | bytes:
-        data: str | bytes = await self._real.recv()
+        try:
+            data: str | bytes = await self._real.recv()
+        except websockets.exceptions.ConnectionClosed as exc:
+            if exc.rcvd is not None:
+                content = struct.pack(">H", exc.rcvd.code) + exc.rcvd.reason.encode()
+                offset_ms = int((time.monotonic() - self._start_time) * 1000)
+                self._frames.append(WsFrame("recv", "close", Body("binary", content), offset_ms))
+            self._flush()
+            raise
         offset_ms = int((time.monotonic() - self._start_time) * 1000)
         if isinstance(data, bytes):
             frame = WsFrame("recv", "binary", Body("binary", data), offset_ms)
@@ -75,7 +85,8 @@ class VCRWebSocketReplay:
 
     def __init__(self, interaction: WsInteraction) -> None:
         self._frames = interaction.frames
-        self._recv_frames = [f for f in self._frames if f.direction == "recv"]
+        self._recv_frames = [f for f in self._frames if f.direction == "recv" and f.frame_type != "close"]
+        self._close = next((f for f in self._frames if f.direction == "recv" and f.frame_type == "close"), None)
         self._recv_index = 0
 
     async def send(self, message: str | bytes) -> None:
@@ -83,6 +94,15 @@ class VCRWebSocketReplay:
 
     async def recv(self) -> str | bytes:
         if self._recv_index >= len(self._recv_frames):
+            if self._close is not None:
+                content = self._close.body.content
+                data = content if isinstance(content, bytes) else b""
+                if len(data) < 2:
+                    raise ValueError("recorded WebSocket close body is shorter than its status code")
+                close = Close(struct.unpack(">H", data[:2])[0], data[2:].decode())
+                if close.code in (1000, 1001):
+                    raise ConnectionClosedOK(close, None)
+                raise ConnectionClosedError(close, None)
             # Recorded frames are exhausted; signal a clean end-of-stream the
             # way a real connection does, so `await ws.recv()` callers see
             # ConnectionClosed instead of a bare StopAsyncIteration.

--- a/src/cassetter/intercept/_websockets.py
+++ b/src/cassetter/intercept/_websockets.py
@@ -8,7 +8,7 @@ from typing import Any
 import websockets
 import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
-from websockets.frames import Close
+from websockets.frames import Close, CloseCode
 
 from cassetter._core import Body, WsFrame, WsInteraction
 from cassetter._state import get_current_cassette
@@ -122,7 +122,7 @@ class VCRWebSocketReplay:
                 if len(data) < 2:
                     raise ValueError("recorded WebSocket close body is shorter than its status code")
                 close = Close(struct.unpack(">H", data[:2])[0], data[2:].decode())
-                if close.code in (1000, 1001):
+                if close.code in (1000, 1001, CloseCode.NO_STATUS_RCVD):
                     raise ConnectionClosedOK(close, None)
                 raise ConnectionClosedError(close, None)
             # Recorded frames are exhausted; signal a clean end-of-stream the

--- a/src/cassetter/intercept/_websockets.py
+++ b/src/cassetter/intercept/_websockets.py
@@ -18,11 +18,21 @@ from cassetter.cassette import NoMatchError
 class VCRWebSocket:
     """Wraps a real WebSocket connection to record sent/received frames."""
 
-    def __init__(self, real_ws: Any, uri: str, headers: dict[str, list[str]]) -> None:
+    def __init__(
+        self,
+        real_ws: Any,
+        uri: str,
+        headers: dict[str, list[str]],
+        subprotocol: str | None = None,
+    ) -> None:
         self._real = real_ws
         self._uri = uri
         self._headers = headers
+        if subprotocol is not None:
+            self._headers["sec-websocket-protocol"] = [subprotocol]
+        self.subprotocol = subprotocol
         self._frames: list[WsFrame] = []
+        self._terminal_recorded = False
         self._start_time = time.monotonic()
 
     async def send(self, message: str | bytes) -> None:
@@ -38,11 +48,13 @@ class VCRWebSocket:
         try:
             data: str | bytes = await self._real.recv()
         except websockets.exceptions.ConnectionClosed as exc:
-            if exc.rcvd is not None:
-                content = struct.pack(">H", exc.rcvd.code) + exc.rcvd.reason.encode()
-                offset_ms = int((time.monotonic() - self._start_time) * 1000)
-                self._frames.append(WsFrame("recv", "close", Body("binary", content), offset_ms))
-            self._flush()
+            if not self._terminal_recorded:
+                self._terminal_recorded = True
+                if exc.rcvd is not None:
+                    content = struct.pack(">H", exc.rcvd.code) + exc.rcvd.reason.encode()
+                    offset_ms = int((time.monotonic() - self._start_time) * 1000)
+                    self._frames.append(WsFrame("recv", "close", Body("binary", content), offset_ms))
+                self._flush()
             raise
         offset_ms = int((time.monotonic() - self._start_time) * 1000)
         if isinstance(data, bytes):
@@ -87,6 +99,14 @@ class VCRWebSocketReplay:
         self._frames = interaction.frames
         self._recv_frames = [f for f in self._frames if f.direction == "recv" and f.frame_type != "close"]
         self._close = next((f for f in self._frames if f.direction == "recv" and f.frame_type == "close"), None)
+        self.subprotocol = next(
+            (
+                values[0]
+                for name, values in interaction.headers.items()
+                if name.lower() == "sec-websocket-protocol" and values
+            ),
+            None,
+        )
         self._recv_index = 0
 
     async def send(self, message: str | bytes) -> None:
@@ -162,7 +182,7 @@ class _PatchedConnect:
         conn = self._original_connect(self._uri, **self._kwargs)  # pragma: no cover
         real_ws = await conn  # pragma: no cover
         headers = extract_ws_headers(self._kwargs)  # pragma: no cover
-        self._ws = VCRWebSocket(real_ws, self._uri, headers)  # pragma: no cover
+        self._ws = VCRWebSocket(real_ws, self._uri, headers, real_ws.subprotocol)  # pragma: no cover
         return self._ws  # pragma: no cover
 
     async def _cleanup(self) -> None:

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -956,7 +956,7 @@ async def test_replay_ws_recv() -> None:
 
     interaction = WsInteraction(
         "wss://ws.example.com",
-        {},
+        {"sec-websocket-protocol": ["chat"]},
         [
             WsFrame("send", "text", Body("text", "ping"), 0),
             WsFrame("recv", "text", Body("text", "pong"), 10),
@@ -964,6 +964,7 @@ async def test_replay_ws_recv() -> None:
         ],
     )
     ws = VCRWebSocketReplay(interaction)
+    assert ws.subprotocol == "chat"
     assert await ws.recv() == "pong"
     assert await ws.recv() == "data"
     # Exhausted replay signals a clean close, like a real connection at EOF
@@ -1077,7 +1078,8 @@ async def test_record_ws_frames(tmp_path: Path) -> None:
 
     token = current_cassette.set(cassette)
     try:
-        ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {})
+        ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {}, "chat")
+        assert ws.subprotocol == "chat"
         await ws.send("hello")
         data = await ws.recv()
         assert data == "response"
@@ -1090,6 +1092,7 @@ async def test_record_ws_frames(tmp_path: Path) -> None:
     assert len(interaction.frames) == 2
     assert interaction.frames[0].direction == "send"
     assert interaction.frames[1].direction == "recv"
+    assert interaction.headers["sec-websocket-protocol"] == ["chat"]
 
 
 @pytest.mark.anyio
@@ -1108,9 +1111,12 @@ async def test_record_ws_close_status(tmp_path: Path) -> None:
         ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {})
         with pytest.raises(ConnectionClosedError):
             await ws.recv()
+        with pytest.raises(ConnectionClosedError):
+            await ws.recv()
     finally:
         current_cassette.reset(token)
 
+    assert len(cassette.ws_interactions) == 1
     frame = cassette.ws_interactions[0].frames[0]
     assert frame.direction == "recv"
     assert frame.frame_type == "close"

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -1118,7 +1118,7 @@ async def test_record_ws_close_status(tmp_path: Path) -> None:
 
     class FakeWs:
         async def recv(self) -> str:
-            raise ConnectionClosedError(Close(1008, "denied"), None)
+            raise ConnectionClosedError(Close(1008, "access_token=secret"), None)
 
     token = current_cassette.set(cassette)
     try:
@@ -1134,7 +1134,7 @@ async def test_record_ws_close_status(tmp_path: Path) -> None:
     frame = cassette.ws_interactions[0].frames[0]
     assert frame.direction == "recv"
     assert frame.frame_type == "close"
-    assert frame.body.content == b"\x03\xf0denied"
+    assert frame.body.content == b"\x03\xf0access_token=[FILTERED]"
 
 
 @pytest.mark.anyio

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -987,6 +987,20 @@ async def test_replay_ws_close_status() -> None:
 
 
 @pytest.mark.anyio
+async def test_replay_ws_normal_close_status() -> None:
+
+    interaction = WsInteraction(
+        "wss://ws.example.com",
+        {},
+        [WsFrame("recv", "close", Body("binary", b"\x03\xe8done"), 10)],
+    )
+    ws = VCRWebSocketReplay(interaction)
+    with pytest.raises(ConnectionClosedOK) as exc_info:
+        await ws.recv()
+    assert exc_info.value.rcvd == Close(1000, "done")
+
+
+@pytest.mark.anyio
 async def test_replay_ws_rejects_short_close_frame() -> None:
 
     interaction = WsInteraction(

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -9,7 +9,8 @@ import grpc.aio
 import pytest
 import websockets.asyncio.client
 import websockets.exceptions
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.frames import Close
 
 from cassetter._core import (
     Body,
@@ -972,6 +973,33 @@ async def test_replay_ws_recv() -> None:
 
 
 @pytest.mark.anyio
+async def test_replay_ws_close_status() -> None:
+
+    interaction = WsInteraction(
+        "wss://ws.example.com",
+        {},
+        [WsFrame("recv", "close", Body("binary", b"\x03\xf0denied"), 10)],
+    )
+    ws = VCRWebSocketReplay(interaction)
+    with pytest.raises(ConnectionClosedError) as exc_info:
+        await ws.recv()
+    assert exc_info.value.rcvd == Close(1008, "denied")
+
+
+@pytest.mark.anyio
+async def test_replay_ws_rejects_short_close_frame() -> None:
+
+    interaction = WsInteraction(
+        "wss://ws.example.com",
+        {},
+        [WsFrame("recv", "close", Body("binary", b"\x03"), 10)],
+    )
+    ws = VCRWebSocketReplay(interaction)
+    with pytest.raises(ValueError, match="shorter than its status code"):
+        await ws.recv()
+
+
+@pytest.mark.anyio
 async def test_replay_ws_send_is_noop() -> None:
 
     interaction = WsInteraction("wss://ws.example.com", {}, [])
@@ -1048,6 +1076,31 @@ async def test_record_ws_frames(tmp_path: Path) -> None:
     assert len(interaction.frames) == 2
     assert interaction.frames[0].direction == "send"
     assert interaction.frames[1].direction == "recv"
+
+
+@pytest.mark.anyio
+async def test_record_ws_close_status(tmp_path: Path) -> None:
+
+    path = os.path.join(str(tmp_path), "ws_close.yaml")
+    cassette = Cassette(path, record_mode=RecordMode.ALL)
+    cassette.load()
+
+    class FakeWs:
+        async def recv(self) -> str:
+            raise ConnectionClosedError(Close(1008, "denied"), None)
+
+    token = current_cassette.set(cassette)
+    try:
+        ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {})
+        with pytest.raises(ConnectionClosedError):
+            await ws.recv()
+    finally:
+        current_cassette.reset(token)
+
+    frame = cassette.ws_interactions[0].frames[0]
+    assert frame.direction == "recv"
+    assert frame.frame_type == "close"
+    assert frame.body.content == b"\x03\xf0denied"
 
 
 @pytest.mark.anyio

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -1124,6 +1124,53 @@ async def test_record_ws_close_status(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_record_ws_abnormal_close(tmp_path: Path) -> None:
+
+    path = os.path.join(str(tmp_path), "ws_abnormal.yaml")
+    cassette = Cassette(path, record_mode=RecordMode.ALL)
+    cassette.load()
+
+    class FakeWs:
+        async def recv(self) -> str:
+            raise ConnectionClosedError(None, None)
+
+    token = current_cassette.set(cassette)
+    try:
+        ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {})
+        with pytest.raises(ConnectionClosedError):
+            await ws.recv()
+    finally:
+        current_cassette.reset(token)
+
+    frame = cassette.ws_interactions[0].frames[0]
+    assert frame.frame_type == "close"
+    assert frame.body.content == b"\x03\xee"
+
+
+@pytest.mark.anyio
+async def test_record_ws_empty_connection(tmp_path: Path) -> None:
+
+    path = os.path.join(str(tmp_path), "ws_empty.yaml")
+    cassette = Cassette(path, record_mode=RecordMode.ALL)
+    cassette.load()
+
+    class FakeWs:
+        async def close(self, code: int = 1000, reason: str = "") -> None:
+            pass
+
+    token = current_cassette.set(cassette)
+    try:
+        ws = VCRWebSocket(FakeWs(), "wss://ws.example.com", {}, "chat")
+        await ws.close()
+    finally:
+        current_cassette.reset(token)
+
+    interaction = cassette.ws_interactions[0]
+    assert interaction.frames == []
+    assert interaction.headers["sec-websocket-protocol"] == ["chat"]
+
+
+@pytest.mark.anyio
 async def test_record_ws_context_manager(tmp_path: Path) -> None:
 
     path = os.path.join(str(tmp_path), "ws_ctx.yaml")

--- a/tests/test_grpc_ws.py
+++ b/tests/test_grpc_ws.py
@@ -1002,6 +1002,20 @@ async def test_replay_ws_normal_close_status() -> None:
 
 
 @pytest.mark.anyio
+async def test_replay_ws_no_status_close() -> None:
+
+    interaction = WsInteraction(
+        "wss://ws.example.com",
+        {},
+        [WsFrame("recv", "close", Body("binary", b"\x03\xed"), 10)],
+    )
+    ws = VCRWebSocketReplay(interaction)
+    with pytest.raises(ConnectionClosedOK) as exc_info:
+        await ws.recv()
+    assert exc_info.value.rcvd == Close(1005, "")
+
+
+@pytest.mark.anyio
 async def test_replay_ws_rejects_short_close_frame() -> None:
 
     interaction = WsInteraction(

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -61,7 +61,7 @@ export interface GrpcInteraction {
 
 export interface WsFrame {
   direction: "send" | "recv";
-  frameType: "text" | "binary";
+  frameType: "text" | "binary" | "close";
   body: Body;
   offsetMs: number;
 }


### PR DESCRIPTION
## Summary

- add an idiomatic `coder/websocket` recording and replay connection
- record text and binary messages with URI matching, repeated playback, bypass policies, filtering, scrubbing, and Unicode normalization
- report incomplete connections and preserve deterministic mixed-protocol ordering
- document the Go WebSocket testing workflow

## Validation

- `go test -race -count=5 ./...`
- `go vet ./...`
- `golangci-lint run ./...`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.