### PR TITLE
Prepare Go v0.1.0 release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,38 @@
+name: Validate Go release
+
+on:
+  push:
+    tags: ["go/v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+      - name: Validate module tag
+        shell: bash
+        run: |
+          VERSION=${GITHUB_REF_NAME#go/}
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid Go module version: $VERSION" >&2
+            exit 1
+          fi
+          test "$(go list -m)" = "github.com/Kludex/cassetter/go"
+      - run: go test -race ./...
+      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          working-directory: go

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -25,10 +25,27 @@ jobs:
         shell: bash
         run: |
           VERSION=${GITHUB_REF_NAME#go/}
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid Go module version: $VERSION" >&2
-            exit 1
-          fi
+          python3 - "$VERSION" <<'PY'
+          import re
+          import sys
+
+          version = sys.argv[1]
+          match = re.fullmatch(
+              r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+              r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?",
+              version,
+          )
+          if match is None:
+              raise SystemExit(f"invalid canonical Go module version: {version}")
+          prerelease = match.group(4)
+          if prerelease is not None:
+              for identifier in prerelease.split("."):
+                  if identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0"):
+                      raise SystemExit(f"invalid canonical Go module version: {version}")
+          if int(match.group(1)) >= 2:
+              raise SystemExit("Go v2+ requires a /vN suffix in the module path")
+          PY
           test "$(go list -m)" = "github.com/Kludex/cassetter/go"
       - run: go test -race ./...
       - run: go vet ./...

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -32,8 +32,7 @@ jobs:
           version = sys.argv[1]
           match = re.fullmatch(
               r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
-              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
-              r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?",
+              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?",
               version,
           )
           if match is None:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build-wheels:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -80,6 +81,7 @@ jobs:
           path: dist/*.whl
 
   build-sdist:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -100,7 +102,7 @@ jobs:
 
   publish:
     needs: [build-wheels, build-sdist]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ uv add cassetter
 Use the Go module when you need HTTP, gRPC, or WebSocket cassette recording:
 
 ```bash
-go get github.com/Kludex/cassetter/go
+go get github.com/Kludex/cassetter/go@v0.1.0
 ```
 
 It reads and writes the same structured YAML and TOML formats, including VCR.py YAML migration. It supports all four

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 0.1.0 - 2026-09-04
+
+This is the first release of the Go SDK.
+
+### Recording and replay
+
+- Added streaming HTTP recording and replay through `http.RoundTripper` with atomic cassette writes and safe default
+  filtering ([#96](https://github.com/Kludex/cassetter/pull/96)).
+- Added deterministic test cleanup, incomplete body detection, and save error reporting
+  ([#100](https://github.com/Kludex/cassetter/pull/100)).
+- Added configurable HTTP request matching, ignored JSON paths, URI normalization, and repeated playback
+  ([#101](https://github.com/Kludex/cassetter/pull/101)).
+- Added expiry policies, host bypass, request and response hooks, and Unicode NFC normalization
+  ([#102](https://github.com/Kludex/cassetter/pull/102)).
+- Added unary and streaming gRPC client interceptors with metadata, status, cancellation, and protobuf support
+  ([#105](https://github.com/Kludex/cassetter/pull/105)).
+- Added WebSocket text, binary, close status, subprotocol, filtering, and lifecycle support through `coder/websocket`
+  ([#106](https://github.com/Kludex/cassetter/pull/106)).
+
+### Formats and tooling
+
+- Added typed HTTP, gRPC, and WebSocket cassette structures shared with Python and Node
+  ([#99](https://github.com/Kludex/cassetter/pull/99)).
+- Added TOML support, YAML and TOML conversion, and VCR.py migration
+  ([#103](https://github.com/Kludex/cassetter/pull/103)).
+- Added `inspect`, `diff`, `scrub`, and `convert` commands for cassette maintenance
+  ([#96](https://github.com/Kludex/cassetter/pull/96), [#103](https://github.com/Kludex/cassetter/pull/103)).
+- Added shared format and behavior conformance fixtures run by Go, Python, and Node
+  ([#104](https://github.com/Kludex/cassetter/pull/104)).

--- a/go/LICENSE
+++ b/go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcelo Trylesinski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/go/README.md
+++ b/go/README.md
@@ -6,8 +6,11 @@ Record and replay Go HTTP, gRPC, and WebSocket traffic with the same structured 
 ## Install
 
 ```bash
-go get github.com/Kludex/cassetter/go
+go get github.com/Kludex/cassetter/go@v0.1.0
 ```
+
+See the [Go changelog](CHANGELOG.md) for release details. Maintainers can use the
+[release checklist](RELEASING.md) for module tags.
 
 ## Record and replay HTTP
 
@@ -307,7 +310,7 @@ Each option adds to the safe defaults.
 ## Inspect, diff, scrub, and convert
 
 ```bash
-go install github.com/Kludex/cassetter/go/cmd/cassetter@latest
+go install github.com/Kludex/cassetter/go/cmd/cassetter@v0.1.0
 
 cassetter inspect tests/cassettes/openai.yaml
 cassetter diff tests/cassettes/openai.yaml tests/cassettes/openai-new.yaml
@@ -326,6 +329,70 @@ overwrite a separate output file.
 `cassetter convert` detects YAML or TOML from each file extension. It filters
 secrets by default, including secrets in VCR.py cassettes. Pass `--no-scrub` to
 preserve the source values. TOML supports HTTP interactions only.
+
+## API reference
+
+### Constructors and lifecycle
+
+| API | Purpose |
+|---|---|
+| `NewTransport` | Create an HTTP `RoundTripper` and shared cassette lifecycle. |
+| `NewGRPCRecorder` | Create the lifecycle used by unary and streaming gRPC interceptors. |
+| `NewWebSocketRecorder` | Create the lifecycle used by `DialWebSocket`. |
+| `NewTestTransport` | Create and immediately initialize an HTTP transport with `testing.TB` cleanup. |
+| `NewTestGRPCRecorder` | Create and initialize a gRPC recorder with `testing.TB` cleanup. |
+| `NewTestWebSocketRecorder` | Create and initialize a WebSocket recorder with `testing.TB` cleanup. |
+| `Transport.Initialize` | Load and validate the cassette before traffic starts. |
+| `Transport.Close` | Save empty replacement runs and report save or incomplete-recording errors. |
+| `Transport.CloseIdleConnections` | Close idle connections held by the wrapped HTTP transport. |
+
+Use `Transport.UnaryClientInterceptor` and `Transport.StreamClientInterceptor`
+with `grpc.ClientConn`. Use `Transport.DialWebSocket` for WebSockets.
+`WebSocketConn` provides `Read`, `Reader`, `Write`, `Writer`, `Ping`,
+`SetReadLimit`, `Subprotocol`, `Close`, and `CloseNow`.
+
+### Options
+
+| Option | Purpose |
+|---|---|
+| `WithPath` | Set the YAML or TOML cassette path. |
+| `WithRecordMode` | Select `none`, `once`, `new_episodes`, `all`, or `rewrite`. |
+| `WithMatchers` | Select HTTP `method`, `uri`, `headers`, `body`, or `json_body` matching. |
+| `WithIgnoredJSONPaths` | Ignore dot-separated paths during HTTP JSON body matching. |
+| `WithURINormalizer` | Normalize HTTP and WebSocket URIs for comparison. |
+| `WithFilterHeaders` | Add request, response, handshake, or metadata names to filter. |
+| `WithFilterQueryParameters` | Add URI query or fragment parameters to filter. |
+| `WithBodyScrubPatterns` | Add JSON or text field patterns to scrub. |
+| `WithFilterReplacement` | Change the value written in place of secrets. |
+| `WithMaxAge` | Set the maximum cassette age. |
+| `WithExpiryAction` | Select `warn`, `fail`, or `rerecord` for expired cassettes. |
+| `WithIgnoreLocalhost` | Bypass recording for loopback hosts. |
+| `WithIgnoreHosts` | Bypass recording for exact hosts or wildcard host patterns. |
+| `WithRequestHook` | Transform or skip a live HTTP request before matching. |
+| `WithResponseHook` | Transform or skip a live HTTP response before recording. |
+
+Options add to the safe filtering defaults. `DefaultSecurityConfig` returns a
+copy of those defaults for `Cassette.Scrub`.
+
+### Cassette data
+
+`Load` reads YAML, TOML, or VCR.py YAML into `Cassette`. `Cassette.Save` writes
+atomically. `Cassette.Scrub` filters an in-memory cassette. `Cassette` exposes
+`Interactions`, `GRPCInteractions`, and `WebSocketInteractions` with typed
+request, response, body, metadata, and frame values.
+
+`Body.Type` is `BodyTypeNone`, `BodyTypeJSON`, `BodyTypeText`, or
+`BodyTypeBinary`. JSON content uses ordinary Go values. Binary content uses
+`[]byte` and is stored as lowercase hexadecimal.
+
+### Errors
+
+Use `errors.Is` with `ErrNoMatch`, `ErrIncompleteRecording`,
+`ErrTransportClosed`, `ErrCassetteExpired`, and `ErrSkipRecording`. Use
+`errors.As` when you need details from `NoMatchError`, `NoGRPCMatchError`,
+`NoWebSocketMatchError`, `IncompleteRecordingError`,
+`IncompleteGRPCRecordingError`, `IncompleteWebSocketRecordingError`, or
+`CassetteExpiredError`.
 
 ## Scope
 

--- a/go/RELEASING.md
+++ b/go/RELEASING.md
@@ -1,0 +1,45 @@
+# Release the Go module
+
+Go module versions use repository tags prefixed with the module directory. For example, Go version `v0.1.0` uses the
+Git tag `go/v0.1.0`. A root tag such as `v0.1.0` belongs to the Python and Node release workflow.
+
+## Verify
+
+```console
+$ git switch main
+$ git pull --ff-only
+$ git status --short
+$ (cd go && go mod verify)
+$ (cd go && go test -race ./...)
+$ (cd go && go vet ./...)
+$ (cd go && golangci-lint run ./...)
+```
+
+Confirm the `main` CI workflow is green. Confirm the release version and notes in `go/CHANGELOG.md`.
+
+## Tag
+
+```console
+$ git tag -a go/v0.1.0 -m "Release Go v0.1.0"
+$ git push origin go/v0.1.0
+```
+
+The `Validate Go release` workflow checks the tag, module path, race tests, vet, and lint. Do not create the GitHub
+release until this workflow passes.
+
+## Publish the GitHub release
+
+Create a non-draft GitHub release from the existing `go/v0.1.0` tag. A Go release does not upload a package artifact.
+The Go module proxy reads the tagged `go/` directory directly. The PyPI workflow ignores tags that do not start with
+`v`.
+
+## Verify the public module
+
+```console
+$ GOPROXY=https://proxy.golang.org go list -m github.com/Kludex/cassetter/go@v0.1.0
+$ GONOSUMDB=github.com/Kludex/cassetter GOPROXY=direct go mod download github.com/Kludex/cassetter/go@v0.1.0
+```
+
+If validation fails before the GitHub release exists, correct the code on `main` and publish a new version tag. Do not
+move or replace a pushed tag. If the GitHub release already exists, inspect the release, tag, and proxy before taking
+any recovery action.

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,0 +1,5 @@
+// Package cassetter records and replays HTTP, gRPC, and WebSocket interactions.
+//
+// Recordings use the shared cassetter YAML format. HTTP-only cassettes may also
+// use TOML. New transports filter common credentials before every atomic write.
+package cassetter


### PR DESCRIPTION
## Summary

- document the complete Go HTTP, gRPC, WebSocket, lifecycle, option, cassette, error, and CLI APIs
- add the first Go changelog, release checklist, package documentation, and module-local license
- validate `go/v*` tags without publishing artifacts
- prevent Go GitHub releases from triggering the PyPI publishing workflow

## Validation

- clean module archive: `go mod verify`, `go test -race ./...`, `go vet ./...`, and CLI build
- `golangci-lint run ./...`
- full Python coverage, Ruff, formatting, and mypy
- Rust formatting, Clippy, and workspace tests
- Node native build, typecheck, and tests
- `actionlint` for every GitHub Actions workflow
- external consumer smoke test through the public Go API

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.