### PR TITLE
Audit Go release dependencies

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -9,7 +9,11 @@ permissions:
 
 jobs:
   validate:
+    name: validate (${{ matrix.go-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25.x", stable]
     defaults:
       run:
         working-directory: go
@@ -19,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: ${{ matrix.go-version }}
           check-latest: true
           cache-dependency-path: go/go.sum
       - name: Validate module tag

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -19,7 +19,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go/go.mod
+          go-version: stable
+          check-latest: true
           cache-dependency-path: go/go.sum
       - name: Validate module tag
         shell: bash
@@ -52,3 +53,4 @@ jobs:
         with:
           version: latest
           working-directory: go
+      - run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...

--- a/go/README.md
+++ b/go/README.md
@@ -12,6 +12,10 @@ go get github.com/Kludex/cassetter/go@v0.1.0
 See the [Go changelog](CHANGELOG.md) for release details. Maintainers can use the
 [release checklist](RELEASING.md) for module tags.
 
+## Requirements
+
+Use Go 1.25 or newer. Install the latest patch release for your Go toolchain.
+
 ## Record and replay HTTP
 
 ```go

--- a/go/RELEASING.md
+++ b/go/RELEASING.md
@@ -13,6 +13,7 @@ $ (cd go && go mod verify)
 $ (cd go && go test -race ./...)
 $ (cd go && go vet ./...)
 $ (cd go && golangci-lint run ./...)
+$ (cd go && go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...)
 ```
 
 Confirm the `main` CI workflow is green. Confirm the release version and notes in `go/CHANGELOG.md`.

--- a/go/RELEASING.md
+++ b/go/RELEASING.md
@@ -6,14 +6,14 @@ Git tag `go/v0.1.0`. A root tag such as `v0.1.0` belongs to the Python and Node 
 ## Verify
 
 ```console
-$ git switch main
-$ git pull --ff-only
-$ git status --short
-$ (cd go && go mod verify)
-$ (cd go && go test -race ./...)
-$ (cd go && go vet ./...)
-$ (cd go && golangci-lint run ./...)
-$ (cd go && go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...)
+git switch main
+git pull --ff-only
+git status --short
+(cd go && go mod verify)
+(cd go && go test -race ./...)
+(cd go && go vet ./...)
+(cd go && golangci-lint run ./...)
+(cd go && go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...)
 ```
 
 Confirm the `main` CI workflow is green. Confirm the release version and notes in `go/CHANGELOG.md`.
@@ -21,8 +21,8 @@ Confirm the `main` CI workflow is green. Confirm the release version and notes i
 ## Tag
 
 ```console
-$ git tag -a go/v0.1.0 -m "Release Go v0.1.0"
-$ git push origin go/v0.1.0
+git tag -a go/v0.1.0 -m "Release Go v0.1.0"
+git push origin go/v0.1.0
 ```
 
 The `Validate Go release` workflow checks the tag, module path, race tests, vet, and lint. Do not create the GitHub
@@ -37,8 +37,8 @@ The Go module proxy reads the tagged `go/` directory directly. The PyPI workflow
 ## Verify the public module
 
 ```console
-$ GOPROXY=https://proxy.golang.org go list -m github.com/Kludex/cassetter/go@v0.1.0
-$ GONOSUMDB=github.com/Kludex/cassetter GOPROXY=direct go mod download github.com/Kludex/cassetter/go@v0.1.0
+GOPROXY=https://proxy.golang.org go list -m github.com/Kludex/cassetter/go@v0.1.0
+GONOSUMDB=github.com/Kludex/cassetter GOPROXY=direct go mod download github.com/Kludex/cassetter/go@v0.1.0
 ```
 
 If validation fails before the GitHub release exists, correct the code on `main` and publish a new version tag. Do not


### PR DESCRIPTION
## Summary

- run Go release validation on the latest stable patched toolchain
- scan reachable package symbols with `govulncheck` before approving a module tag
- document the minimum Go version and patched-toolchain requirement

## Validation

- Go 1.26.8 race tests and vet
- `govulncheck` v1.7.0 reports no vulnerabilities
- `actionlint` passes for every workflow

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.