### PR TITLE
Add native Rust HTTP and gRPC recording

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
 version: 2
 updates:
-  # serde-saphyr is on the critical path for parsing every cassette and is
-  # still 0.0.x, which cargo pins exactly - only dependabot can move it.
   - package-ecosystem: cargo
-    directory: /rust
+    directory: /
     schedule:
       interval: weekly
     cooldown:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,18 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
 
+  rust-msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # 1.88.0
+        with:
+          toolchain: 1.88.0
+      - run: sudo apt-get update && sudo apt-get install -y libpython3-dev
+      - run: cargo check --workspace --all-targets
+
   go-test:
     permissions:
       contents: read
@@ -141,7 +153,7 @@ jobs:
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
-    needs: [lint, rust-test, go-test, audit, test, node]
+    needs: [lint, rust-test, rust-msrv, go-test, audit, test, node]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,10 @@ jobs:
           content = content.replace(placeholder, f'version = "{version}"')
           if content.count(f'version = "{version}"') != 1:
               raise SystemExit("workspace release version was not updated exactly once")
+          dependency = 'version = "=0.0.0"'
+          if content.count(dependency) != 1:
+              raise SystemExit("Rust SDK core dependency placeholder is missing or duplicated")
+          content = content.replace(dependency, f'version = "={version}"')
           path.write_text(content)
           PY
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -174,6 +178,10 @@ jobs:
           content = content.replace(placeholder, f'version = "{version}"')
           if content.count(f'version = "{version}"') != 1:
               raise SystemExit("workspace release version was not updated exactly once")
+          dependency = 'version = "=0.0.0"'
+          if content.count(dependency) != 1:
+              raise SystemExit("Rust SDK core dependency placeholder is missing or duplicated")
+          content = content.replace(dependency, f'version = "={version}"')
           path.write_text(content)
           PY
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -399,30 +407,36 @@ jobs:
           content = content.replace(placeholder, f'version = "{version}"')
           if content.count(f'version = "{version}"') != 1:
               raise SystemExit("workspace release version was not updated exactly once")
+          dependency = 'version = "=0.0.0"'
+          if content.count(dependency) != 1:
+              raise SystemExit("Rust SDK core dependency placeholder is missing or duplicated")
+          content = content.replace(dependency, f'version = "={version}"')
           path.write_text(content)
           PY
-      - run: cargo package -p cassetter-core --allow-dirty
-      - name: Inspect Rust artifact
+      - run: cargo package -p cassetter-core -p cassetter --allow-dirty
+      - name: Inspect Rust artifacts
         env:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
-          crate="target/package/cassetter-core-${VERSION}.crate"
-          test -f "$crate"
-          tar -tzf "$crate" > crate-files.txt
-          grep -Fx "cassetter-core-${VERSION}/Cargo.toml" crate-files.txt
-          grep -Fx "cassetter-core-${VERSION}/LICENSE" crate-files.txt
-          grep -Fx "cassetter-core-${VERSION}/README.md" crate-files.txt
-          grep -Fx "cassetter-core-${VERSION}/src/lib.rs" crate-files.txt
+          for package in cassetter-core cassetter; do
+            crate="target/package/${package}-${VERSION}.crate"
+            test -f "$crate"
+            tar -tzf "$crate" > "${package}-crate-files.txt"
+            grep -Fx "${package}-${VERSION}/Cargo.toml" "${package}-crate-files.txt"
+            grep -Fx "${package}-${VERSION}/LICENSE" "${package}-crate-files.txt"
+            grep -Fx "${package}-${VERSION}/README.md" "${package}-crate-files.txt"
+            grep -Fx "${package}-${VERSION}/src/lib.rs" "${package}-crate-files.txt"
+          done
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: crates-io-dist
-          path: target/package/cassetter-core-*.crate
+          path: target/package/cassetter*.crate
           if-no-files-found: error
 
   tag-go:
     name: tag Go module
-    needs: [version, validate-go, publish-pypi, publish-npm, publish-crates-io]
-    if: ${{ !cancelled() && github.event_name == 'push' && needs.validate-go.result == 'success' && needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-crates-io.result == 'success' }}
+    needs: [version, validate-go, publish-pypi, publish-npm, publish-rust-sdk]
+    if: ${{ !cancelled() && github.event_name == 'push' && needs.validate-go.result == 'success' && needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'success' && needs.publish-rust-sdk.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -559,6 +573,46 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
         run: cargo publish --manifest-path "$CRATE_DIR/cassetter-core-${VERSION}/Cargo.toml" --no-verify --allow-dirty
 
+  publish-rust-sdk:
+    name: publish Rust SDK to crates.io
+    needs: [version, package-rust, publish-crates-io]
+    if: ${{ !cancelled() && github.event_name == 'push' && needs.package-rust.result == 'success' && needs.publish-crates-io.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/cassetter/${{ needs.version.outputs.version }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: crates-io-dist
+          path: ${{ runner.temp }}/crates-io-dist
+      - name: Extract verified crate
+        env:
+          CRATE_DIR: ${{ runner.temp }}/crates-io-dist
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          tar -xzf "$CRATE_DIR/cassetter-${VERSION}.crate" -C "$CRATE_DIR"
+          rm "$CRATE_DIR/cassetter-${VERSION}/Cargo.toml.orig"
+      - name: Authenticate to crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+      - name: Publish verified crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+          CRATE_DIR: ${{ runner.temp }}/crates-io-dist
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          for attempt in {1..20}; do
+            if cargo publish --manifest-path "$CRATE_DIR/cassetter-${VERSION}/Cargo.toml" --no-verify --allow-dirty; then
+              exit 0
+            fi
+            sleep 15
+          done
+          exit 1
+
   smoke-check:
     name: check release artifact smoke test
     needs: [ci, validate-go, build-wheels, build-sdist, package-npm, package-rust]
@@ -571,7 +625,7 @@ jobs:
 
   release-check:
     name: check coordinated release
-    needs: [tag-go, publish-pypi, publish-npm, publish-crates-io]
+    needs: [tag-go, publish-pypi, publish-npm, publish-crates-io, publish-rust-sdk]
     if: ${{ always() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -571,7 +571,11 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
           CRATE_DIR: ${{ runner.temp }}/crates-io-dist
           VERSION: ${{ needs.version.outputs.version }}
-        run: cargo publish --manifest-path "$CRATE_DIR/cassetter-core-${VERSION}/Cargo.toml" --no-verify --allow-dirty
+        run: |
+          if cargo publish --manifest-path "$CRATE_DIR/cassetter-core-${VERSION}/Cargo.toml" --no-verify --allow-dirty; then
+            exit 0
+          fi
+          cargo info "cassetter-core@${VERSION}" >/dev/null 2>&1
 
   publish-rust-sdk:
     name: publish Rust SDK to crates.io
@@ -607,6 +611,9 @@ jobs:
         run: |
           for attempt in {1..20}; do
             if cargo publish --manifest-path "$CRATE_DIR/cassetter-${VERSION}/Cargo.toml" --no-verify --allow-dirty; then
+              exit 0
+            fi
+            if cargo info "cassetter@${VERSION}" >/dev/null 2>&1; then
               exit 0
             fi
             sleep 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,10 +50,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -62,10 +85,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -95,10 +173,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cassetter"
+version = "0.0.0"
+dependencies = [
+ "bytes",
+ "cassetter-core",
+ "googleapis-tonic-google-cloud-tasks-v2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jiff",
+ "percent-encoding",
+ "prost",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tonic-health",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "cassetter-core"
 version = "0.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "brotli",
  "flate2",
  "regex",
@@ -178,6 +292,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +364,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +396,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +462,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "googleapis-tonic-google-api"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca39f3577e656ca9ad97737fc1a397f45c46f54d047a43af1fb680287b5ace8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-cloud-tasks-v2"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0fc81f5010066571cf54550e33ea91f5e47302e60db93bd94e1c0b1c5f8f65"
+dependencies = [
+ "googleapis-tonic-google-api",
+ "googleapis-tonic-google-iam-v1",
+ "googleapis-tonic-google-rpc",
+ "googleapis-tonic-google-type",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-iam-v1"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66603b0825eda597e1acb5fa39fcfd44065c09b626c3a5541a40626c50ea7912"
+dependencies = [
+ "googleapis-tonic-google-api",
+ "googleapis-tonic-google-type",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-rpc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f8922a81782e57325a059334bcec9730f7865eea2a1a1453896efe53a65b6af"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "googleapis-tonic-google-type"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc35fc04d6bb84eab8fff7c6a40357bfd647af0d5dfc41597a4ae6d8e0d84a2d"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "granit-parser"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +535,25 @@ checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
 dependencies = [
  "arraydeque",
  "smallvec",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -252,6 +569,213 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,10 +786,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -275,6 +850,17 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -294,10 +880,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -310,12 +926,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "napi"
 version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -390,6 +1017,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,12 +1061,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -522,6 +1231,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
+dependencies = [
+ "base64 0.23.0",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,7 +1303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb49c0aa8a5bb88c00b833c11bae50d1611fb89e01336f53b05f7c643b1c883"
 dependencies = [
  "annotate-snippets",
- "base64",
+ "base64 0.23.0",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",
@@ -610,10 +1369,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -638,10 +1419,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tinyvec"
@@ -657,6 +1501,58 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -698,6 +1594,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +1760,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,10 +1802,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"
@@ -750,6 +1892,89 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/cassetter-core",
+    "crates/cassetter",
     "crates/cassetter-python",
     "crates/cassetter-node",
 ]
@@ -9,13 +10,13 @@ members = [
 [workspace.package]
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/Kludex/cassetter"
 homepage = "https://kludex.github.io/cassetter/"
 
 [workspace.dependencies]
-cassetter-core = { path = "crates/cassetter-core" }
+cassetter-core = { path = "crates/cassetter-core", version = "=0.0.0" }
 serde = { version = "1", features = ["derive"] }
 # `preserve_order` keeps a recorded JSON body in the order the server sent it, so a
 # cassette stays a faithful recording rather than an alphabetized rewrite of one.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Rust-powered HTTP cassette recorder. Safe by default.
 
-Available for **Python** (this README) and **Node/TypeScript** ([`ts/`](ts)).
-Both are thin bindings over one Rust core, so a cassette recorded by either
-is readable by the other.
+Available for **Python** (this README), **Node/TypeScript** ([`ts/`](ts)),
+**Go** ([`go/`](go)), and **Rust** ([`crates/cassetter/`](crates/cassetter)).
+Every SDK uses the same cassette format.
 
 ## Why?
 
@@ -35,6 +35,18 @@ go get github.com/Kludex/cassetter/go@v0.1.0
 It reads and writes the same structured YAML and TOML formats, including VCR.py YAML migration. It supports all four
 gRPC call patterns and WebSocket text and binary messages with YAML cassettes. It also provides `inspect`, `diff`,
 `scrub`, and `convert` commands. See the [Go documentation](go/README.md) for complete examples and record modes.
+
+## Rust
+
+Use the Rust crate when the code under test sends requests through `reqwest` or a generated `tonic` client:
+
+```bash
+cargo add cassetter reqwest
+```
+
+The Rust SDK uses explicit transport injection. It supports async HTTP and unary gRPC recording, exact protobuf
+request matching, concurrent use, safe filtering, and explicit finalization. See the
+[Rust documentation](crates/cassetter/README.md) for complete examples and current streaming limits.
 
 ## Quick start
 
@@ -606,11 +618,12 @@ so the parts that matter cannot drift apart.
 ```
 crates/
   cassetter-core/     pure Rust: format, matching, security, body processing
+  cassetter/          async Rust SDK   -> reqwest and tonic
   cassetter-python/   PyO3 bindings    -> cassetter._core
   cassetter-node/     napi-rs bindings -> cassetter.node
 src/cassetter/        Python package (interceptors, pytest plugin, CLI)
 ts/                   Node package (fetch interception)
-conformance/          shared fixture both bindings must reproduce
+conformance/          shared fixtures every SDK must reproduce
 ```
 
 A binding only implements what is genuinely language-specific: HTTP library
@@ -624,7 +637,7 @@ bindings - see its README for the contract.
 
 ## Development
 
-Requires a Rust toolchain, Python 3.10+, and Node 18+ for the Node binding.
+Requires Rust 1.88+, Python 3.10+, and Node 18+ for the Node binding.
 
 ```bash
 git clone https://github.com/Kludex/cassetter.git

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ release.
 | --- | --- | --- |
 | `pypi` | `cassetter` | `.github/workflows/publish.yml` |
 | `npm` | `cassetter` | `.github/workflows/publish.yml` |
-| `crates-io` | `cassetter-core` | `.github/workflows/publish.yml` |
+| `crates-io` | `cassetter-core`, then `cassetter` | `.github/workflows/publish.yml` |
 
 Configure each registry to trust its environment and this workflow. PyPI, npm,
 and crates.io issue short-lived tokens through OpenID Connect (OIDC), so the
@@ -30,8 +30,9 @@ gh run watch "${run_url##*/}" --exit-status
 ```
 
 Use the intended release version. A manual run executes the complete CI suite,
-builds every artifact, installs the npm package, packages the Rust crate, and
-validates the Go module. It does not publish or create a tag.
+builds every artifact, installs the npm package, packages both Rust crates, and
+validates the Go module. It does not publish or create a tag. A tag run publishes
+`cassetter-core` before the dependent `cassetter` Rust SDK.
 
 ## Create the release tag
 
@@ -72,6 +73,7 @@ all four ecosystems.
 python -m pip index versions cassetter
 npm view cassetter@0.11.0 version
 cargo info cassetter-core@0.11.0
+cargo info cassetter@0.11.0
 GOPROXY=https://proxy.golang.org go list -m github.com/Kludex/cassetter/go@v0.11.0
 ```
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -280,15 +280,15 @@ Bindings that exchange plain data rather than wrapping every type in a native cl
 
 - **Test bindings against each other at runtime.** Requires every language's toolchain in one CI job. Rejected as fragile; a committed fixture gives each binding an independent check.
 
-**Why this choice:** a new binding gets a concrete definition of correct, and a change that makes two bindings disagree fails CI instead of surfacing as an unreadable cassette later.
+**Why this choice:** a new binding gets a concrete definition of correct, and a change that makes SDKs disagree fails CI instead of surfacing as an unreadable cassette later.
 
 ## 9. Scope and non-goals
 
 ### Implemented
 - Binding-free Rust core shared by every language, with a cross-language conformance suite
-- Python bindings (PyO3) and Node bindings (napi-rs)
-- HTTP recording/replay for httpx, aiohttp, requests, urllib3 (Python) and `fetch` (Node)
-- gRPC message recording via grpcio
+- Python bindings (PyO3), Node bindings (napi-rs), and native Go and Rust SDKs
+- HTTP recording/replay for httpx, aiohttp, requests, urllib3, `fetch`, Go `net/http`, and Rust `reqwest`
+- gRPC recording via grpcio, Go interceptors, and injected Rust `tonic` transports
 - WebSocket frame recording via websockets
 - Structured YAML cassette format with typed bodies
 - Safe-by-default security filtering

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -60,6 +60,7 @@ A format case passes when an SDK parses its cassette into the corresponding cano
 | Python | `tests/test_conformance.py`, `tests/test_*_conformance.py` |
 | Node | `ts/tests/*conformance.test.ts` |
 | Go | `go/conformance_test.go`, `go/*_conformance_test.go` |
+| Rust | `crates/cassetter/tests/conformance.rs` |
 
 Each SDK reads the shared manifests. Add a case once and every implementation receives it.
 The nested Go module includes a synchronized copy under `go/testdata/conformance/`.
@@ -74,6 +75,7 @@ $ cp -R conformance go/testdata/conformance
 $ uv run pytest tests/test_conformance.py tests/test_*_conformance.py
 $ (cd ts && npm test -- --run tests/conformance.test.ts tests/behavior-conformance.test.ts tests/record-modes-conformance.test.ts)
 $ (cd go && go test ./...)
+$ cargo test -p cassetter --test conformance
 ```
 
 Add the input and expected result to the appropriate directory.

--- a/crates/cassetter-core/README.md
+++ b/crates/cassetter-core/README.md
@@ -13,5 +13,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Use a language SDK when you need client interception. The core crate provides
+Use the [`cassetter`](https://crates.io/crates/cassetter) crate when you need
+async `reqwest` or unary `tonic` transport integration. The core crate provides
 protocol-neutral data structures and persistence for custom integrations.

--- a/crates/cassetter-core/src/body/hex.rs
+++ b/crates/cassetter-core/src/body/hex.rs
@@ -7,7 +7,7 @@ pub fn encode(data: &[u8]) -> String {
 
 /// Decode a lowercase/uppercase hex string into bytes.
 pub fn decode(s: &str) -> Result<Vec<u8>, String> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err("odd-length hex string".to_string());
     }
     if !s.is_ascii() {

--- a/crates/cassetter-core/src/cassette/mod.rs
+++ b/crates/cassetter-core/src/cassette/mod.rs
@@ -6,7 +6,7 @@ pub mod ordering;
 use std::path::Path;
 
 use crate::matching::config::MatchConfig;
-use crate::protocol::grpc::GrpcInteraction;
+use crate::protocol::grpc::{GrpcInteraction, GrpcRequest};
 use crate::protocol::http::{HttpInteraction, HttpRequest};
 use crate::protocol::ws::WsInteraction;
 use crate::{CassetteError, Result};
@@ -50,6 +50,19 @@ impl Cassette {
         self.interactions.push(interaction);
         self.played_indices.push(false);
         self.index = None;
+    }
+
+    /// Insert an HTTP interaction at an output position, unplayed.
+    pub fn insert_interaction(&mut self, index: usize, interaction: HttpInteraction) -> Result<()> {
+        if index > self.interactions.len() {
+            return Err(CassetteError::IndexOutOfRange(
+                "interaction insert index out of range".to_string(),
+            ));
+        }
+        self.interactions.insert(index, interaction);
+        self.played_indices.insert(index, false);
+        self.index = None;
+        Ok(())
     }
 
     /// Mark an HTTP interaction played.
@@ -112,6 +125,22 @@ impl Cassette {
         self.grpc_played.push(false);
     }
 
+    /// Insert a gRPC interaction at an output position, unplayed.
+    pub fn insert_grpc_interaction(
+        &mut self,
+        index: usize,
+        interaction: GrpcInteraction,
+    ) -> Result<()> {
+        if index > self.grpc_interactions.len() {
+            return Err(CassetteError::IndexOutOfRange(
+                "gRPC interaction insert index out of range".to_string(),
+            ));
+        }
+        self.grpc_interactions.insert(index, interaction);
+        self.grpc_played.insert(index, false);
+        Ok(())
+    }
+
     /// Mark a gRPC interaction played.
     pub fn mark_grpc_played(&mut self, index: usize) -> Result<()> {
         if index >= self.grpc_played.len() {
@@ -127,6 +156,22 @@ impl Cassette {
     pub fn take_grpc_match(&mut self, method: &str) -> Option<(usize, GrpcInteraction)> {
         let idx = crate::matching::find_grpc_match_index(
             method,
+            &self.grpc_interactions,
+            &self.grpc_played,
+        )?;
+        if let Some(played) = self.grpc_played.get_mut(idx) {
+            *played = true;
+        }
+        Some((idx, self.grpc_interactions[idx].clone()))
+    }
+
+    /// Find a gRPC interaction with the same method and request body, then mark it played.
+    pub fn take_grpc_request_match(
+        &mut self,
+        request: &GrpcRequest,
+    ) -> Option<(usize, GrpcInteraction)> {
+        let idx = crate::matching::find_grpc_request_match_index(
+            request,
             &self.grpc_interactions,
             &self.grpc_played,
         )?;

--- a/crates/cassetter-core/src/lib.rs
+++ b/crates/cassetter-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod cassette;
 pub mod interop;
 pub mod matching;
 pub mod protocol;
+pub mod recording;
 pub mod security;
 
 use std::fmt;

--- a/crates/cassetter-core/src/matching/mod.rs
+++ b/crates/cassetter-core/src/matching/mod.rs
@@ -2,7 +2,7 @@ pub mod config;
 pub mod matchers;
 
 use crate::cassette::index::CassetteIndex;
-use crate::protocol::grpc::GrpcInteraction;
+use crate::protocol::grpc::{GrpcInteraction, GrpcRequest};
 use crate::protocol::http::{HttpInteraction, HttpRequest};
 use crate::protocol::ws::WsInteraction;
 use config::MatchConfig;
@@ -98,6 +98,29 @@ pub fn find_grpc_match_index(
     let mut fallback = None;
     for (idx, interaction) in interactions.iter().enumerate() {
         if interaction.request.method != method {
+            continue;
+        }
+        if !played.get(idx).copied().unwrap_or(false) {
+            return Some(idx);
+        }
+        if fallback.is_none() {
+            fallback = Some(idx);
+        }
+    }
+    fallback
+}
+
+/// Index of a gRPC interaction matching the method and serialized request body.
+/// Prefers unplayed interactions; falls back to an already-played interaction.
+pub fn find_grpc_request_match_index(
+    request: &GrpcRequest,
+    interactions: &[GrpcInteraction],
+    played: &[bool],
+) -> Option<usize> {
+    let mut fallback = None;
+    for (idx, interaction) in interactions.iter().enumerate() {
+        if interaction.request.method != request.method || interaction.request.body != request.body
+        {
             continue;
         }
         if !played.get(idx).copied().unwrap_or(false) {
@@ -230,5 +253,31 @@ mod tests {
     fn test_unknown_matcher_is_rejected_at_construction() {
         assert!(MatchConfig::new(Some(vec!["bogus".to_string()]), None).is_err());
         assert!(MatchConfig::new(Some(vec![]), None).is_err());
+    }
+
+    #[test]
+    fn test_grpc_request_matching_includes_the_body() {
+        use crate::protocol::grpc::{GrpcRequest, GrpcResponse};
+
+        let interaction = GrpcInteraction::new(
+            GrpcRequest::new(
+                "/demo.Service/Get".to_string(),
+                None,
+                Some(Body::binary(vec![1])),
+            ),
+            GrpcResponse::new(0, None, None, None),
+            String::new(),
+            None,
+        );
+        let different = GrpcRequest::new(
+            "/demo.Service/Get".to_string(),
+            None,
+            Some(Body::binary(vec![2])),
+        );
+
+        assert_eq!(
+            find_grpc_request_match_index(&different, &[interaction], &[false]),
+            None
+        );
     }
 }

--- a/crates/cassetter-core/src/recording.rs
+++ b/crates/cassetter-core/src/recording.rs
@@ -1,0 +1,50 @@
+/// Controls whether a cassette replays or records requests.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RecordMode {
+    /// Replay only. A missing interaction is an error.
+    None,
+    /// Record a new cassette when no cassette exists, otherwise replay only.
+    #[default]
+    Once,
+    /// Replay matching interactions and record requests that do not match.
+    NewEpisodes,
+    /// Record every request and replace the existing interactions.
+    All,
+    /// Remove the existing cassette, then record every request.
+    Rewrite,
+}
+
+impl RecordMode {
+    /// Whether existing interactions can be replayed in this mode.
+    pub fn replays(self) -> bool {
+        !matches!(self, RecordMode::All | RecordMode::Rewrite)
+    }
+
+    /// Whether a request can be recorded in this mode.
+    pub fn can_record(self, cassette_exists: bool) -> bool {
+        matches!(
+            self,
+            RecordMode::NewEpisodes | RecordMode::All | RecordMode::Rewrite
+        ) || self == RecordMode::Once && !cassette_exists
+    }
+
+    /// Whether opening the cassette starts with no existing interactions.
+    pub fn replaces(self) -> bool {
+        matches!(self, RecordMode::All | RecordMode::Rewrite)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_modes_define_replay_and_recording_policy() {
+        assert!(!RecordMode::None.can_record(false));
+        assert!(RecordMode::Once.can_record(false));
+        assert!(!RecordMode::Once.can_record(true));
+        assert!(RecordMode::NewEpisodes.replays());
+        assert!(!RecordMode::All.replays());
+        assert!(RecordMode::Rewrite.replaces());
+    }
+}

--- a/crates/cassetter/Cargo.toml
+++ b/crates/cassetter/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "cassetter"
+description = "Async Rust HTTP and gRPC cassette recording and replay."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/cassetter"
+readme = "README.md"
+keywords = ["cassette", "http", "grpc", "recording", "testing"]
+categories = ["development-tools::testing", "web-programming::http-client"]
+exclude = ["tests"]
+
+[features]
+default = ["reqwest", "tonic"]
+reqwest = ["dep:bytes", "dep:http", "dep:http-body-util", "dep:reqwest"]
+tonic = [
+    "dep:bytes",
+    "dep:http",
+    "dep:http-body",
+    "dep:http-body-util",
+    "dep:percent-encoding",
+    "dep:tonic",
+    "dep:tower-service",
+]
+
+[dependencies]
+cassetter-core.workspace = true
+jiff = { version = "0.2.15", default-features = false, features = ["std"] }
+bytes = { version = "1", optional = true }
+http = { version = "1", optional = true }
+http-body = { version = "1", optional = true }
+http-body-util = { version = "0.1", optional = true }
+percent-encoding = { version = "2", optional = true }
+reqwest = { version = "0.13", default-features = false, optional = true }
+serde_json.workspace = true
+tonic = { version = "0.14", default-features = false, features = ["codegen"], optional = true }
+tower-service = { version = "0.3", optional = true }
+
+[dev-dependencies]
+googleapis-tonic-google-cloud-tasks-v2 = "=0.34.0"
+prost = "0.14"
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
+serde.workspace = true
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tonic = { version = "0.14", features = ["transport"] }
+tonic-health = "0.14"
+tower = { version = "0.5", features = ["util"] }
+
+[lints]
+workspace = true

--- a/crates/cassetter/Cargo.toml
+++ b/crates/cassetter/Cargo.toml
@@ -45,7 +45,7 @@ prost = "0.14"
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde.workspace = true
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tonic = { version = "0.14", features = ["transport"] }
 tonic-health = "0.14"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/cassetter/LICENSE
+++ b/crates/cassetter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcelo Trylesinski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/cassetter/README.md
+++ b/crates/cassetter/README.md
@@ -1,0 +1,95 @@
+# cassetter for Rust
+
+Record and replay outbound HTTP and unary gRPC calls with the same cassette files as the Python, Node, and Go SDKs.
+
+## Install
+
+```console
+cargo add cassetter reqwest
+```
+
+Add `tonic` and your generated gRPC client crate when you need gRPC recording. The crate requires Rust 1.88 or newer.
+
+## HTTP with reqwest
+
+```rust,no_run
+use cassetter::{RecordMode, Recorder};
+use reqwest::{Method, Request, Url};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let recorder = Recorder::builder("tests/cassettes/users.yaml")
+    .record_mode(RecordMode::Once)
+    .build()?;
+let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+let request = Request::new(Method::GET, Url::parse("https://api.example.com/users")?);
+let response = client.execute(request).await?;
+let body = response.bytes().await?;
+assert!(!body.is_empty());
+recorder.finish().await?;
+# Ok(())
+# }
+```
+
+The wrapper buffers request and response bodies. This makes matching
+deterministic and reports body read failures before the call returns. Use
+`Client::inner()` to build requests with the wrapped client's configuration.
+
+## gRPC with tonic
+
+```rust,no_run
+use cassetter::{RecordMode, Recorder};
+use tonic::transport::Channel;
+use tonic_health::pb::health_client::HealthClient;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let recorder = Recorder::builder("tests/cassettes/health.yaml")
+    .record_mode(RecordMode::Once)
+    .build()?;
+let channel = Channel::from_static("https://api.example.com").connect_lazy();
+let service = cassetter::tonic::GrpcService::new(channel, recorder.clone());
+let mut client = HealthClient::new(service);
+let _ = client
+    .check(tonic_health::pb::HealthCheckRequest::default())
+    .await?;
+recorder.finish().await?;
+# Ok(())
+# }
+```
+
+Pass `GrpcService` to any generated `tonic` client that accepts a transport in
+its `new` constructor. Matching uses the full RPC method and exact serialized
+protobuf request body. Request metadata is recorded. Response headers and
+trailers are merged into the v1 cassette `metadata` field and exposed in both
+places during replay. Non-OK gRPC statuses are recorded and replayed.
+
+## Record modes
+
+| Mode | Behavior |
+|---|---|
+| `RecordMode::None` | Replay only. A missing or mismatched request fails. |
+| `RecordMode::Once` | Record if the cassette does not exist, otherwise replay only. |
+| `RecordMode::NewEpisodes` | Replay matches and record misses. |
+| `RecordMode::All` | Record every request and replace existing interactions. |
+| `RecordMode::Rewrite` | Remove the cassette first and record every request. |
+
+Each `Recorder` owns independent playback state. Clone one recorder to share a
+cassette safely across concurrent tasks. Build separate recorders when tests
+must not consume each other's interactions.
+
+Always call `Recorder::finish`. It saves an empty replacement cassette when
+needed and reports persistence failures or calls cancelled while recording.
+
+## Current limits
+
+- HTTP request and response bodies are buffered in memory.
+- gRPC supports unary calls only. Client-streaming, server-streaming, and
+  bidirectional calls are rejected because the transport requires exactly one
+  framed request and response message.
+- Compressed gRPC messages are rejected.
+- Protobuf payloads are stored as binary bytes. Header filtering applies to
+  metadata, but body field filtering cannot inspect binary protobuf data.
+  Filter sensitive protobuf fields before they reach the transport. A future
+  descriptor-aware API can add safe field-level filtering.
+- The v1 cassette format has one response metadata map. Headers and trailers
+  are merged when recording and replayed in both locations.
+- gRPC interactions require YAML. TOML cassettes support HTTP only.

--- a/crates/cassetter/examples/reqwest.rs
+++ b/crates/cassetter/examples/reqwest.rs
@@ -1,0 +1,16 @@
+use cassetter::{RecordMode, Recorder};
+use reqwest::{Method, Request, Url};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = Recorder::builder("tests/cassettes/users.yaml")
+        .record_mode(RecordMode::Once)
+        .build()?;
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    let request = Request::new(Method::GET, Url::parse("https://api.example.com/users")?);
+    let response = client.execute(request).await?;
+
+    let _body = response.text().await?;
+    recorder.finish().await?;
+    Ok(())
+}

--- a/crates/cassetter/examples/tonic.rs
+++ b/crates/cassetter/examples/tonic.rs
@@ -1,0 +1,18 @@
+use cassetter::{RecordMode, Recorder};
+use tonic::transport::Channel;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = Recorder::builder("tests/cassettes/health.yaml")
+        .record_mode(RecordMode::Once)
+        .build()?;
+    let channel = Channel::from_static("https://api.example.com").connect_lazy();
+    let service = cassetter::tonic::GrpcService::new(channel, recorder.clone());
+    let mut client = HealthClient::new(service);
+
+    let _response = client.check(HealthCheckRequest::default()).await?;
+    recorder.finish().await?;
+    Ok(())
+}

--- a/crates/cassetter/src/config.rs
+++ b/crates/cassetter/src/config.rs
@@ -1,0 +1,119 @@
+use std::path::{Path, PathBuf};
+
+use cassetter_core::matching::config::MatchConfig;
+pub use cassetter_core::recording::RecordMode;
+use cassetter_core::security::SecurityConfig;
+
+use crate::{Error, Recorder, Result};
+
+/// Configures a [`Recorder`].
+#[derive(Debug)]
+pub struct RecorderBuilder {
+    pub(crate) path: PathBuf,
+    pub(crate) mode: RecordMode,
+    pub(crate) matching: MatchConfig,
+    pub(crate) security: SecurityConfig,
+}
+
+impl RecorderBuilder {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            mode: RecordMode::Once,
+            matching: MatchConfig::default(),
+            security: SecurityConfig::default(),
+        }
+    }
+
+    /// Select the record mode.
+    pub fn record_mode(mut self, mode: RecordMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Select the HTTP request fields used for matching.
+    pub fn match_on<I, S>(mut self, fields: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.matching
+            .set_match_on(fields.into_iter().map(Into::into).collect())?;
+        Ok(self)
+    }
+
+    /// Ignore dot-separated JSON paths while using the `json_body` matcher.
+    pub fn ignore_json_paths<I, S>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.matching.ignore_json_paths = paths.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Add header or gRPC metadata names to the safe filtering defaults.
+    pub fn filter_headers<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        extend_unique(&mut self.security.filter_headers, names);
+        self
+    }
+
+    /// Add URI query parameter names to the safe filtering defaults.
+    pub fn filter_query_parameters<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        extend_unique(&mut self.security.filter_query_parameters, names);
+        self
+    }
+
+    /// Add JSON or text field patterns to the safe filtering defaults.
+    pub fn body_scrub_patterns<I, S>(mut self, patterns: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut combined = self.security.body_scrub_patterns.clone();
+        extend_unique(&mut combined, patterns);
+        self.security.set_body_scrub_patterns(combined)?;
+        Ok(self)
+    }
+
+    /// Change the placeholder written in place of filtered values.
+    pub fn filter_replacement(mut self, replacement: impl Into<String>) -> Self {
+        self.security.replacement = replacement.into();
+        self
+    }
+
+    /// Load or initialize the cassette.
+    pub fn build(self) -> Result<Recorder> {
+        Recorder::from_builder(self)
+    }
+}
+
+fn extend_unique<I, S>(values: &mut Vec<String>, extra: I)
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    for value in extra {
+        let value = value.into();
+        if !values
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(&value))
+        {
+            values.push(value);
+        }
+    }
+}
+
+pub(crate) fn path_text(path: &Path) -> Result<&str> {
+    path.to_str().ok_or_else(|| {
+        Error::InvalidTransportData(format!("cassette path is not valid UTF-8: {path:?}"))
+    })
+}

--- a/crates/cassetter/src/error.rs
+++ b/crates/cassetter/src/error.rs
@@ -1,0 +1,75 @@
+use std::fmt;
+
+/// An error produced while recording or replaying traffic.
+#[derive(Debug)]
+pub enum Error {
+    /// The cassette configuration or file is invalid.
+    Core(cassetter_core::CassetteError),
+    /// No recorded interaction matched the request and recording is disabled.
+    NoMatch {
+        protocol: &'static str,
+        request: String,
+    },
+    /// The recorder was used after finalization.
+    Finalized,
+    /// One or more requests were still in flight at finalization.
+    Incomplete(Vec<String>),
+    /// Recording or persistence failed.
+    Recording(Vec<String>),
+    /// An HTTP body, header, or response could not be represented.
+    InvalidTransportData(String),
+    /// The live HTTP request failed.
+    #[cfg(feature = "reqwest")]
+    Reqwest(reqwest::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Core(error) => error.fmt(f),
+            Error::NoMatch { protocol, request } => {
+                write!(
+                    f,
+                    "no matching {protocol} cassette interaction for {request}"
+                )
+            }
+            Error::Finalized => f.write_str("cassetter recorder is finalized"),
+            Error::Incomplete(requests) => {
+                write!(f, "incomplete cassette recordings: {}", requests.join(", "))
+            }
+            Error::Recording(errors) => {
+                write!(f, "cassette recording failed: {}", errors.join("; "))
+            }
+            Error::InvalidTransportData(message) => f.write_str(message),
+            #[cfg(feature = "reqwest")]
+            Error::Reqwest(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Core(error) => Some(error),
+            #[cfg(feature = "reqwest")]
+            Error::Reqwest(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<cassetter_core::CassetteError> for Error {
+    fn from(error: cassetter_core::CassetteError) -> Self {
+        Error::Core(error)
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        Error::Reqwest(error)
+    }
+}
+
+/// The result type returned by this crate.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/cassetter/src/lib.rs
+++ b/crates/cassetter/src/lib.rs
@@ -1,0 +1,30 @@
+//! Async HTTP and gRPC recording and replay for Rust.
+//!
+//! [`Recorder`] owns one cassette lifecycle. Inject [`reqwest::Client`] or
+//! [`tonic::GrpcService`] explicitly into the client under test, then call
+//! [`Recorder::finish`] so persistence and incomplete recordings cannot be
+//! silently ignored.
+
+mod config;
+mod error;
+mod recorder;
+mod recorder_state;
+#[cfg(feature = "reqwest")]
+mod reqwest_body;
+#[cfg(feature = "tonic")]
+mod tonic_body;
+#[cfg(feature = "tonic")]
+mod tonic_metadata;
+
+#[cfg(feature = "reqwest")]
+pub mod reqwest;
+#[cfg(feature = "tonic")]
+pub mod tonic;
+
+pub use config::{RecordMode, RecorderBuilder};
+pub use error::{Error, Result};
+pub use recorder::Recorder;
+#[cfg(feature = "reqwest")]
+pub use reqwest::Client as ReqwestClient;
+#[cfg(feature = "tonic")]
+pub use tonic::GrpcService;

--- a/crates/cassetter/src/recorder.rs
+++ b/crates/cassetter/src/recorder.rs
@@ -1,0 +1,230 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+#[cfg(feature = "tonic")]
+use cassetter_core::protocol::grpc::{GrpcInteraction, GrpcRequest};
+#[cfg(feature = "reqwest")]
+use cassetter_core::protocol::http::{HttpInteraction, HttpRequest, HttpResponse};
+#[cfg(feature = "tonic")]
+use cassetter_core::security::scrub_grpc_interaction;
+#[cfg(feature = "reqwest")]
+use cassetter_core::security::scrub_interaction;
+
+use crate::config::{path_text, RecorderBuilder};
+#[cfg(feature = "reqwest")]
+use crate::recorder_state::retag_content_length;
+use crate::recorder_state::State;
+use crate::{Error, Result};
+
+/// A concurrency-safe cassette shared by injected HTTP and gRPC transports.
+#[must_use = "call Recorder::finish to report persistence and incomplete-recording errors"]
+#[derive(Clone, Debug)]
+pub struct Recorder {
+    inner: Arc<Mutex<State>>,
+}
+
+#[cfg(any(feature = "reqwest", feature = "tonic"))]
+pub(crate) enum Action<T> {
+    Replay(T),
+    Record(usize),
+}
+
+impl Recorder {
+    /// Configure a recorder backed by `path`.
+    pub fn builder(path: impl Into<PathBuf>) -> RecorderBuilder {
+        RecorderBuilder::new(path.into())
+    }
+
+    pub(crate) fn from_builder(builder: RecorderBuilder) -> Result<Self> {
+        Ok(Self {
+            inner: Arc::new(Mutex::new(State::from_builder(builder)?)),
+        })
+    }
+
+    /// Persist the cassette and report every failed or incomplete recording.
+    ///
+    /// Call this after all clients that share the recorder have finished.
+    pub async fn finish(&self) -> Result<()> {
+        let save_empty = {
+            let mut state = self.lock()?;
+            let save_empty = !state.finalized && state.save_empty;
+            state.finalized = true;
+            save_empty
+        };
+
+        if save_empty {
+            if let Err(error) = self.save() {
+                self.remember_error(error.to_string())?;
+            }
+        }
+        let state = self.lock()?;
+        let pending = state.pending.values().cloned().collect::<Vec<_>>();
+        if !pending.is_empty() && state.errors.is_empty() {
+            return Err(Error::Incomplete(pending));
+        }
+        let mut errors = state.errors.clone();
+        errors.extend(
+            pending
+                .into_iter()
+                .map(|request| format!("incomplete recording for {request}")),
+        );
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::Recording(errors))
+        }
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub(crate) fn prepare_http(&self, request: &HttpRequest) -> Result<Action<HttpResponse>> {
+        let mut state = self.lock()?;
+        ensure_open(&state)?;
+        if state.mode.replays() {
+            let probe = scrub_interaction(
+                &HttpInteraction::new(
+                    request.clone(),
+                    HttpResponse::new(0, None, None),
+                    String::new(),
+                ),
+                &state.security,
+            );
+            let matching = state.matching.clone();
+            if let Some((_, interaction)) = state.cassette.take_match(&probe.request, &matching) {
+                return Ok(Action::Replay(interaction.response));
+            }
+        }
+        reserve(
+            &mut state,
+            "HTTP",
+            format!("{} {}", request.method, request.uri),
+        )
+    }
+
+    #[cfg(feature = "tonic")]
+    pub(crate) fn prepare_grpc(&self, request: &GrpcRequest) -> Result<Action<GrpcInteraction>> {
+        let mut state = self.lock()?;
+        ensure_open(&state)?;
+        if state.mode.replays() {
+            let probe = scrub_grpc_interaction(
+                &GrpcInteraction::new(
+                    request.clone(),
+                    cassetter_core::protocol::grpc::GrpcResponse::new(0, None, None, None),
+                    String::new(),
+                    None,
+                ),
+                &state.security,
+            );
+            if let Some((_, interaction)) = state.cassette.take_grpc_request_match(&probe.request) {
+                return Ok(Action::Replay(interaction));
+            }
+        }
+        reserve(&mut state, "gRPC", request.method.clone())
+    }
+
+    #[cfg(feature = "reqwest")]
+    pub(crate) fn record_http(&self, order: usize, interaction: HttpInteraction) -> Result<()> {
+        {
+            let mut state = self.lock()?;
+            ensure_open(&state)?;
+            let mut interaction = scrub_interaction(&interaction, &state.security);
+            let retagged =
+                retag_content_length(&mut interaction.request.headers, &interaction.request.body)
+                    .and_then(|()| {
+                        retag_content_length(
+                            &mut interaction.response.headers,
+                            &interaction.response.body,
+                        )
+                    });
+            if let Err(error) = retagged {
+                state.pending.remove(&order);
+                state.errors.push(error.to_string());
+                return Err(error);
+            }
+            let position = state.http_order.partition_point(|current| *current < order);
+            state.http_order.insert(position, order);
+            state.cassette.insert_interaction(position, interaction)?;
+            state.pending.remove(&order);
+            state.save_empty = false;
+        }
+        self.save().map_err(|error| self.recording_error(error))
+    }
+
+    #[cfg(feature = "tonic")]
+    pub(crate) fn record_grpc(&self, order: usize, interaction: GrpcInteraction) -> Result<()> {
+        {
+            let mut state = self.lock()?;
+            ensure_open(&state)?;
+            let interaction = scrub_grpc_interaction(&interaction, &state.security);
+            let position = state.grpc_order.partition_point(|current| *current < order);
+            state.grpc_order.insert(position, order);
+            state
+                .cassette
+                .insert_grpc_interaction(position, interaction)?;
+            state.pending.remove(&order);
+            state.save_empty = false;
+        }
+        self.save().map_err(|error| self.recording_error(error))
+    }
+
+    #[cfg(any(feature = "reqwest", feature = "tonic"))]
+    pub(crate) fn fail_recording(&self, order: usize, error: impl ToString) -> Result<()> {
+        let mut state = self.lock()?;
+        state.pending.remove(&order);
+        state.errors.push(error.to_string());
+        Ok(())
+    }
+
+    #[cfg(any(feature = "reqwest", feature = "tonic"))]
+    fn recording_error(&self, error: Error) -> Error {
+        let message = error.to_string();
+        let _ = self.remember_error(message.clone());
+        Error::Recording(vec![message])
+    }
+
+    fn remember_error(&self, error: String) -> Result<()> {
+        self.lock()?.errors.push(error);
+        Ok(())
+    }
+
+    fn save(&self) -> Result<()> {
+        let state = self.lock()?;
+        let order = state
+            .cassette
+            .output_order(Some(&state.matching), Some(&state.http_order));
+        state
+            .cassette
+            .save(path_text(&state.path)?, Some(&order), state.file_mode)
+            .map_err(Error::Core)
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, State>> {
+        self.inner.lock().map_err(|_| {
+            Error::InvalidTransportData("cassetter recorder lock was poisoned".to_string())
+        })
+    }
+}
+
+#[cfg(any(feature = "reqwest", feature = "tonic"))]
+fn reserve<T>(state: &mut State, protocol: &'static str, request: String) -> Result<Action<T>> {
+    if !state.can_record {
+        return Err(Error::NoMatch { protocol, request });
+    }
+    let order = state.next_order;
+    state.next_order += 1;
+    state.pending.insert(order, format!("{protocol} {request}"));
+    Ok(Action::Record(order))
+}
+
+#[cfg(any(feature = "reqwest", feature = "tonic"))]
+fn ensure_open(state: &State) -> Result<()> {
+    if state.finalized {
+        Err(Error::Finalized)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "reqwest", feature = "tonic"))]
+pub(crate) fn recorded_at() -> String {
+    jiff::Timestamp::now().to_string()
+}

--- a/crates/cassetter/src/recorder.rs
+++ b/crates/cassetter/src/recorder.rs
@@ -127,15 +127,10 @@ impl Recorder {
             let mut state = self.lock()?;
             ensure_open(&state)?;
             let mut interaction = scrub_interaction(&interaction, &state.security);
-            let retagged =
-                retag_content_length(&mut interaction.request.headers, &interaction.request.body)
-                    .and_then(|()| {
-                        retag_content_length(
-                            &mut interaction.response.headers,
-                            &interaction.response.body,
-                        )
-                    });
-            if let Err(error) = retagged {
+            if let Err(error) = retag_content_length(
+                &mut interaction.response.headers,
+                &interaction.response.body,
+            ) {
                 state.pending.remove(&order);
                 state.errors.push(error.to_string());
                 return Err(error);

--- a/crates/cassetter/src/recorder_state.rs
+++ b/crates/cassetter/src/recorder_state.rs
@@ -1,0 +1,118 @@
+use std::collections::BTreeMap;
+#[cfg(feature = "reqwest")]
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use cassetter_core::cassette::Cassette;
+use cassetter_core::matching::config::MatchConfig;
+#[cfg(feature = "reqwest")]
+use cassetter_core::protocol::http::{Body, BodyContent};
+use cassetter_core::security::SecurityConfig;
+
+use crate::config::{path_text, RecordMode, RecorderBuilder};
+#[cfg(feature = "reqwest")]
+use crate::Error;
+use crate::Result;
+
+#[derive(Debug)]
+pub(crate) struct State {
+    pub(crate) path: PathBuf,
+    pub(crate) cassette: Cassette,
+    #[cfg_attr(not(any(feature = "reqwest", feature = "tonic")), allow(dead_code))]
+    pub(crate) mode: RecordMode,
+    #[cfg_attr(not(any(feature = "reqwest", feature = "tonic")), allow(dead_code))]
+    pub(crate) can_record: bool,
+    pub(crate) matching: MatchConfig,
+    #[cfg_attr(not(any(feature = "reqwest", feature = "tonic")), allow(dead_code))]
+    pub(crate) security: SecurityConfig,
+    #[cfg_attr(not(any(feature = "reqwest", feature = "tonic")), allow(dead_code))]
+    pub(crate) next_order: usize,
+    pub(crate) http_order: Vec<usize>,
+    #[cfg_attr(not(feature = "tonic"), allow(dead_code))]
+    pub(crate) grpc_order: Vec<usize>,
+    pub(crate) pending: BTreeMap<usize, String>,
+    pub(crate) errors: Vec<String>,
+    pub(crate) save_empty: bool,
+    pub(crate) file_mode: Option<u32>,
+    pub(crate) finalized: bool,
+}
+
+impl State {
+    pub(crate) fn from_builder(builder: RecorderBuilder) -> Result<Self> {
+        let exists = builder.path.exists();
+        let preserved_mode = file_mode(&builder.path);
+        if builder.mode == RecordMode::Rewrite && exists {
+            fs::remove_file(&builder.path).map_err(|error| {
+                cassetter_core::CassetteError::Io(format!(
+                    "remove {}: {error}",
+                    builder.path.display()
+                ))
+            })?;
+        }
+
+        let load_existing = exists && !builder.mode.replaces();
+        let cassette = if load_existing {
+            Cassette::load(path_text(&builder.path)?)?
+        } else {
+            Cassette::new()
+        };
+        let can_record = builder.mode.can_record(exists);
+        let http_count = cassette.interactions.len();
+        let grpc_count = cassette.grpc_interactions.len();
+        let next_order = http_count + grpc_count + cassette.ws_interactions.len();
+
+        Ok(Self {
+            path: builder.path,
+            cassette,
+            mode: builder.mode,
+            can_record,
+            matching: builder.matching,
+            security: builder.security,
+            next_order,
+            http_order: (0..http_count).collect(),
+            grpc_order: (0..grpc_count).collect(),
+            pending: BTreeMap::new(),
+            errors: Vec::new(),
+            save_empty: exists && builder.mode == RecordMode::All,
+            file_mode: preserved_mode,
+            finalized: false,
+        })
+    }
+}
+
+#[cfg(feature = "reqwest")]
+pub(crate) fn retag_content_length(
+    headers: &mut HashMap<String, Vec<String>>,
+    body: &Body,
+) -> Result<()> {
+    let length = match &body.inner {
+        BodyContent::None => 0,
+        BodyContent::Binary(value) => value.len(),
+        BodyContent::Text(value) => value.len(),
+        BodyContent::Json(value) => serde_json::to_vec(value)
+            .map_err(|error| Error::InvalidTransportData(format!("encode JSON body: {error}")))?
+            .len(),
+    };
+    if let Some((_, values)) = headers
+        .iter_mut()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+    {
+        *values = vec![length.to_string()];
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn file_mode(path: &std::path::Path) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.permissions().mode())
+}
+
+#[cfg(not(unix))]
+fn file_mode(_path: &std::path::Path) -> Option<u32> {
+    None
+}

--- a/crates/cassetter/src/recorder_state.rs
+++ b/crates/cassetter/src/recorder_state.rs
@@ -87,7 +87,7 @@ pub(crate) fn retag_content_length(
     body: &Body,
 ) -> Result<()> {
     let length = match &body.inner {
-        BodyContent::None => 0,
+        BodyContent::None => return Ok(()),
         BodyContent::Binary(value) => value.len(),
         BodyContent::Text(value) => value.len(),
         BodyContent::Json(value) => serde_json::to_vec(value)

--- a/crates/cassetter/src/reqwest.rs
+++ b/crates/cassetter/src/reqwest.rs
@@ -32,7 +32,7 @@ impl Client {
     /// Execute a request, replaying a match or recording the live response.
     pub async fn execute(&self, mut request: Request) -> Result<Response> {
         let request_bytes = collect_request_body(&mut request).await?;
-        let headers = headers_to_map(request.headers())?;
+        let headers = headers_to_map(request.headers());
         let recorded_request = HttpRequest::new(
             request.method().as_str().to_string(),
             request.url().as_str().to_string(),
@@ -65,13 +65,7 @@ impl Client {
                         return Err(Error::Reqwest(error));
                     }
                 };
-                let response_headers_map = match headers_to_map(&response_headers) {
-                    Ok(headers) => headers,
-                    Err(error) => {
-                        self.recorder.fail_recording(order, &error)?;
-                        return Err(error);
-                    }
-                };
+                let response_headers_map = headers_to_map(&response_headers);
                 let response_body = match process_body(
                     response_bytes.to_vec(),
                     header(&response_headers_map, "content-type"),

--- a/crates/cassetter/src/reqwest.rs
+++ b/crates/cassetter/src/reqwest.rs
@@ -1,0 +1,108 @@
+//! Explicit [`reqwest`] client integration.
+
+use cassetter_core::body::compression::DEFAULT_MAX_DECOMPRESSED;
+use cassetter_core::body::process_body;
+use cassetter_core::protocol::http::{HttpInteraction, HttpRequest, HttpResponse};
+use reqwest::{Request, Response};
+
+use crate::recorder::{recorded_at, Action};
+use crate::reqwest_body::{
+    build_response, collect_request_body, header, headers_to_map, replay_response,
+};
+use crate::{Error, Recorder, Result};
+
+/// A `reqwest` client that records and replays complete HTTP exchanges.
+#[derive(Clone, Debug)]
+pub struct Client {
+    inner: reqwest::Client,
+    recorder: Recorder,
+}
+
+impl Client {
+    /// Wrap an existing client with an explicit recorder.
+    pub fn new(inner: reqwest::Client, recorder: Recorder) -> Self {
+        Self { inner, recorder }
+    }
+
+    /// Return the wrapped client for building requests with its configuration.
+    pub fn inner(&self) -> &reqwest::Client {
+        &self.inner
+    }
+
+    /// Execute a request, replaying a match or recording the live response.
+    pub async fn execute(&self, mut request: Request) -> Result<Response> {
+        let request_bytes = collect_request_body(&mut request).await?;
+        let headers = headers_to_map(request.headers())?;
+        let recorded_request = HttpRequest::new(
+            request.method().as_str().to_string(),
+            request.url().as_str().to_string(),
+            Some(headers.clone()),
+            Some(process_body(
+                request_bytes.to_vec(),
+                header(&headers, "content-type"),
+                header(&headers, "content-encoding"),
+                DEFAULT_MAX_DECOMPRESSED,
+            )?),
+        );
+
+        match self.recorder.prepare_http(&recorded_request)? {
+            Action::Replay(response) => replay_response(request.url().clone(), response),
+            Action::Record(order) => {
+                let response = match self.inner.execute(request).await {
+                    Ok(response) => response,
+                    Err(error) => {
+                        self.recorder.fail_recording(order, &error)?;
+                        return Err(Error::Reqwest(error));
+                    }
+                };
+                let status = response.status();
+                let response_headers = response.headers().clone();
+                let url = response.url().clone();
+                let response_bytes = match response.bytes().await {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        self.recorder.fail_recording(order, &error)?;
+                        return Err(Error::Reqwest(error));
+                    }
+                };
+                let response_headers_map = match headers_to_map(&response_headers) {
+                    Ok(headers) => headers,
+                    Err(error) => {
+                        self.recorder.fail_recording(order, &error)?;
+                        return Err(error);
+                    }
+                };
+                let response_body = match process_body(
+                    response_bytes.to_vec(),
+                    header(&response_headers_map, "content-type"),
+                    header(&response_headers_map, "content-encoding"),
+                    DEFAULT_MAX_DECOMPRESSED,
+                ) {
+                    Ok(body) => body,
+                    Err(error) => {
+                        let error = Error::Core(error);
+                        self.recorder.fail_recording(order, &error)?;
+                        return Err(error);
+                    }
+                };
+                let stored_headers = response_headers_map
+                    .into_iter()
+                    .filter(|(name, _)| !name.eq_ignore_ascii_case("content-encoding"))
+                    .collect();
+                self.recorder.record_http(
+                    order,
+                    HttpInteraction::new(
+                        recorded_request,
+                        HttpResponse::new(
+                            status.as_u16(),
+                            Some(stored_headers),
+                            Some(response_body),
+                        ),
+                        recorded_at(),
+                    ),
+                )?;
+                build_response(status, response_headers, response_bytes.to_vec(), url)
+            }
+        }
+    }
+}

--- a/crates/cassetter/src/reqwest_body.rs
+++ b/crates/cassetter/src/reqwest_body.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use cassetter_core::protocol::http::{Body, BodyContent, HttpResponse};
+use http_body_util::BodyExt;
+use reqwest::{Request, Response, ResponseBuilderExt};
+
+use crate::{Error, Result};
+
+pub(crate) async fn collect_request_body(request: &mut Request) -> Result<bytes::Bytes> {
+    let Some(body) = request.body_mut().take() else {
+        return Ok(bytes::Bytes::new());
+    };
+    let collected = body
+        .collect()
+        .await
+        .map_err(|error| Error::InvalidTransportData(format!("read HTTP request body: {error}")))?;
+    let bytes = collected.to_bytes();
+    *request.body_mut() = Some(reqwest::Body::from(bytes.clone()));
+    Ok(bytes)
+}
+
+pub(crate) fn headers_to_map(
+    headers: &reqwest::header::HeaderMap,
+) -> Result<HashMap<String, Vec<String>>> {
+    let mut output = HashMap::new();
+    for (name, value) in headers {
+        let value = value.to_str().map_err(|error| {
+            Error::InvalidTransportData(format!("HTTP header {name:?} is not text: {error}"))
+        })?;
+        output
+            .entry(name.as_str().to_string())
+            .or_insert_with(Vec::new)
+            .push(value.to_string());
+    }
+    Ok(output)
+}
+
+pub(crate) fn replay_response(url: reqwest::Url, response: HttpResponse) -> Result<Response> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    for (name, values) in response.headers {
+        let name = reqwest::header::HeaderName::try_from(name).map_err(|error| {
+            Error::InvalidTransportData(format!("invalid recorded HTTP header name: {error}"))
+        })?;
+        for value in values {
+            headers.append(
+                name.clone(),
+                reqwest::header::HeaderValue::try_from(value).map_err(|error| {
+                    Error::InvalidTransportData(format!(
+                        "invalid recorded HTTP header value: {error}"
+                    ))
+                })?,
+            );
+        }
+    }
+    build_response(
+        reqwest::StatusCode::from_u16(response.status).map_err(|error| {
+            Error::InvalidTransportData(format!("invalid recorded HTTP status: {error}"))
+        })?,
+        headers,
+        body_bytes(response.body)?,
+        url,
+    )
+}
+
+pub(crate) fn build_response(
+    status: reqwest::StatusCode,
+    headers: reqwest::header::HeaderMap,
+    body: Vec<u8>,
+    url: reqwest::Url,
+) -> Result<Response> {
+    let mut response = http::Response::builder()
+        .status(status)
+        .url(url)
+        .body(reqwest::Body::from(body))
+        .map_err(|error| Error::InvalidTransportData(format!("build HTTP response: {error}")))?;
+    *response.headers_mut() = headers;
+    Ok(response.into())
+}
+
+pub(crate) fn header<'a>(headers: &'a HashMap<String, Vec<String>>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+        .and_then(|(_, values)| values.first())
+        .map(String::as_str)
+}
+
+fn body_bytes(body: Body) -> Result<Vec<u8>> {
+    match body.inner {
+        BodyContent::None => Ok(Vec::new()),
+        BodyContent::Binary(bytes) => Ok(bytes),
+        BodyContent::Text(text) => Ok(text.into_bytes()),
+        BodyContent::Json(value) => serde_json::to_vec(&value).map_err(|error| {
+            Error::InvalidTransportData(format!("encode recorded JSON body: {error}"))
+        }),
+    }
+}

--- a/crates/cassetter/src/reqwest_body.rs
+++ b/crates/cassetter/src/reqwest_body.rs
@@ -19,20 +19,17 @@ pub(crate) async fn collect_request_body(request: &mut Request) -> Result<bytes:
     Ok(bytes)
 }
 
-pub(crate) fn headers_to_map(
-    headers: &reqwest::header::HeaderMap,
-) -> Result<HashMap<String, Vec<String>>> {
+pub(crate) fn headers_to_map(headers: &reqwest::header::HeaderMap) -> HashMap<String, Vec<String>> {
     let mut output = HashMap::new();
     for (name, value) in headers {
-        let value = value.to_str().map_err(|error| {
-            Error::InvalidTransportData(format!("HTTP header {name:?} is not text: {error}"))
-        })?;
-        output
-            .entry(name.as_str().to_string())
-            .or_insert_with(Vec::new)
-            .push(value.to_string());
+        if let Ok(value) = value.to_str() {
+            output
+                .entry(name.as_str().to_string())
+                .or_insert_with(Vec::new)
+                .push(value.to_string());
+        }
     }
-    Ok(output)
+    output
 }
 
 pub(crate) fn replay_response(url: reqwest::Url, response: HttpResponse) -> Result<Response> {

--- a/crates/cassetter/src/tonic.rs
+++ b/crates/cassetter/src/tonic.rs
@@ -116,7 +116,7 @@ where
                     let interaction = (|| {
                         let response_payload = decode_optional_grpc_frame(&framed_response)?;
                         let (status_code, status_message) =
-                            grpc_status(&response_parts.headers, &trailers);
+                            grpc_status(response_parts.status, &response_parts.headers, &trailers)?;
                         let mut metadata = metadata_to_map(&response_parts.headers)?;
                         merge_metadata(&mut metadata, metadata_to_map(&trailers)?);
                         Ok::<_, Error>(GrpcInteraction::new(

--- a/crates/cassetter/src/tonic.rs
+++ b/crates/cassetter/src/tonic.rs
@@ -1,0 +1,154 @@
+//! Explicit [`tonic`] transport integration for unary calls.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use cassetter_core::protocol::grpc::{GrpcInteraction, GrpcRequest, GrpcResponse};
+use cassetter_core::protocol::http::Body;
+use http::{Request, Response};
+use http_body::Body as HttpBody;
+use http_body_util::BodyExt;
+use tower_service::Service;
+
+use crate::recorder::{recorded_at, Action};
+use crate::tonic_body::{
+    decode_grpc_frame, decode_optional_grpc_frame, replay_response, FramesBody,
+};
+use crate::tonic_metadata::{grpc_status, merge_metadata, metadata_to_map};
+use crate::{Error, Recorder};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+/// A `tonic` service that records and replays unary RPCs.
+///
+/// Pass this service to a generated client's `new` constructor. Clones share
+/// the supplied [`Recorder`], while separately built recorders remain isolated.
+#[derive(Clone, Debug)]
+pub struct GrpcService<S> {
+    inner: S,
+    recorder: Recorder,
+}
+
+impl<S> GrpcService<S> {
+    /// Wrap a channel or another compatible `tonic` transport.
+    pub fn new(inner: S, recorder: Recorder) -> Self {
+        Self { inner, recorder }
+    }
+
+    /// Return the wrapped transport.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+}
+
+impl<S, B> Service<Request<::tonic::body::Body>> for GrpcService<S>
+where
+    S: Service<Request<::tonic::body::Body>, Response = Response<B>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    B: HttpBody<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    type Response = Response<::tonic::body::Body>;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<::tonic::body::Body>) -> Self::Future {
+        let replacement = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, replacement);
+        let recorder = self.recorder.clone();
+
+        Box::pin(async move {
+            let (parts, body) = request.into_parts();
+            let collected = body.collect().await.map_err(boxed)?;
+            if collected.trailers().is_some() {
+                return Err(boxed(Error::InvalidTransportData(
+                    "gRPC request trailers are not supported".to_string(),
+                )));
+            }
+            let framed_request = collected.to_bytes();
+            let request_body = decode_grpc_frame(&framed_request).map_err(boxed)?;
+            let method = parts.uri.path().to_string();
+            let recorded_request = GrpcRequest::new(
+                method,
+                Some(metadata_to_map(&parts.headers).map_err(boxed)?),
+                Some(Body::binary(request_body)),
+            );
+
+            match recorder.prepare_grpc(&recorded_request).map_err(boxed)? {
+                Action::Replay(interaction) => replay_response(interaction.response).map_err(boxed),
+                Action::Record(order) => {
+                    let request = Request::from_parts(
+                        parts,
+                        ::tonic::body::Body::new(http_body_util::Full::new(framed_request)),
+                    );
+                    if let Err(error) = std::future::poll_fn(|cx| inner.poll_ready(cx)).await {
+                        let error = error.into();
+                        recorder.fail_recording(order, &error).map_err(boxed)?;
+                        return Err(error);
+                    }
+                    let response = match inner.call(request).await {
+                        Ok(response) => response,
+                        Err(error) => {
+                            let error = error.into();
+                            recorder.fail_recording(order, &error).map_err(boxed)?;
+                            return Err(error);
+                        }
+                    };
+                    let (response_parts, response_body) = response.into_parts();
+                    let collected = match response_body.collect().await {
+                        Ok(collected) => collected,
+                        Err(error) => {
+                            let error = error.into();
+                            recorder.fail_recording(order, &error).map_err(boxed)?;
+                            return Err(error);
+                        }
+                    };
+                    let trailers = collected.trailers().cloned().unwrap_or_default();
+                    let framed_response = collected.to_bytes();
+                    let interaction = (|| {
+                        let response_payload = decode_optional_grpc_frame(&framed_response)?;
+                        let (status_code, status_message) =
+                            grpc_status(&response_parts.headers, &trailers);
+                        let mut metadata = metadata_to_map(&response_parts.headers)?;
+                        merge_metadata(&mut metadata, metadata_to_map(&trailers)?);
+                        Ok::<_, Error>(GrpcInteraction::new(
+                            recorded_request,
+                            GrpcResponse::new(
+                                status_code,
+                                Some(status_message),
+                                Some(metadata),
+                                Some(response_payload.map_or_else(Body::none, Body::binary)),
+                            ),
+                            recorded_at(),
+                            None,
+                        ))
+                    })();
+                    let interaction = match interaction {
+                        Ok(interaction) => interaction,
+                        Err(error) => {
+                            recorder.fail_recording(order, &error).map_err(boxed)?;
+                            return Err(boxed(error));
+                        }
+                    };
+                    recorder.record_grpc(order, interaction).map_err(boxed)?;
+                    Ok(Response::from_parts(
+                        response_parts,
+                        ::tonic::body::Body::new(FramesBody::new(framed_response, trailers)),
+                    ))
+                }
+            }
+        })
+    }
+}
+
+fn boxed(error: impl Into<BoxError>) -> BoxError {
+    error.into()
+}

--- a/crates/cassetter/src/tonic_body.rs
+++ b/crates/cassetter/src/tonic_body.rs
@@ -1,0 +1,139 @@
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use cassetter_core::protocol::grpc::GrpcResponse;
+use cassetter_core::protocol::http::{Body, BodyContent};
+use http::{HeaderMap, Response};
+use http_body::{Body as HttpBody, Frame};
+
+use crate::tonic_metadata::map_to_headers;
+use crate::Error;
+
+pub(crate) fn replay_response(
+    response: GrpcResponse,
+) -> Result<Response<::tonic::body::Body>, Error> {
+    let framed = match body_bytes(response.body)? {
+        Some(payload) => encode_grpc_frame(&payload)?,
+        None => Vec::new(),
+    };
+    let mut metadata = map_to_headers(response.metadata)?;
+    metadata.insert(
+        "content-type",
+        http::HeaderValue::from_static("application/grpc"),
+    );
+    let mut trailers = metadata.clone();
+    trailers.insert(
+        "grpc-status",
+        http::HeaderValue::try_from(response.status_code.to_string()).map_err(|error| {
+            Error::InvalidTransportData(format!("invalid recorded gRPC status: {error}"))
+        })?,
+    );
+    let encoded_message = percent_encoding::utf8_percent_encode(
+        &response.status_message,
+        percent_encoding::NON_ALPHANUMERIC,
+    )
+    .to_string();
+    trailers.insert(
+        "grpc-message",
+        http::HeaderValue::try_from(encoded_message).map_err(|error| {
+            Error::InvalidTransportData(format!("invalid recorded gRPC status message: {error}"))
+        })?,
+    );
+    Response::builder()
+        .status(http::StatusCode::OK)
+        .body(::tonic::body::Body::new(FramesBody::new(
+            Bytes::from(framed),
+            trailers,
+        )))
+        .map(|mut replay| {
+            *replay.headers_mut() = metadata;
+            replay
+        })
+        .map_err(|error| Error::InvalidTransportData(format!("build gRPC response: {error}")))
+}
+
+pub(crate) fn decode_grpc_frame(bytes: &[u8]) -> Result<Vec<u8>, Error> {
+    if bytes.len() < 5 {
+        return Err(Error::InvalidTransportData(
+            "gRPC unary request is missing its message frame".to_string(),
+        ));
+    }
+    if bytes[0] != 0 {
+        return Err(Error::InvalidTransportData(
+            "compressed gRPC messages are not supported".to_string(),
+        ));
+    }
+    let length = u32::from_be_bytes(bytes[1..5].try_into().expect("fixed frame prefix")) as usize;
+    if bytes.len() != length + 5 {
+        return Err(Error::InvalidTransportData(
+            "gRPC transport supports exactly one unary message".to_string(),
+        ));
+    }
+    Ok(bytes[5..].to_vec())
+}
+
+pub(crate) fn decode_optional_grpc_frame(bytes: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    if bytes.is_empty() {
+        Ok(None)
+    } else {
+        decode_grpc_frame(bytes).map(Some)
+    }
+}
+
+fn encode_grpc_frame(payload: &[u8]) -> Result<Vec<u8>, Error> {
+    let length = u32::try_from(payload.len()).map_err(|_| {
+        Error::InvalidTransportData(
+            "recorded gRPC message exceeds the 4 GiB frame limit".to_string(),
+        )
+    })?;
+    let mut frame = Vec::with_capacity(payload.len() + 5);
+    frame.push(0);
+    frame.extend_from_slice(&length.to_be_bytes());
+    frame.extend_from_slice(payload);
+    Ok(frame)
+}
+
+fn body_bytes(body: Body) -> Result<Option<Vec<u8>>, Error> {
+    match body.inner {
+        BodyContent::None => Ok(None),
+        BodyContent::Binary(bytes) => Ok(Some(bytes)),
+        _ => Err(Error::InvalidTransportData(
+            "recorded gRPC body is not binary".to_string(),
+        )),
+    }
+}
+
+pub(crate) struct FramesBody {
+    frames: VecDeque<Frame<Bytes>>,
+}
+
+impl FramesBody {
+    pub(crate) fn new(data: Bytes, trailers: HeaderMap) -> Self {
+        let mut frames = VecDeque::new();
+        if !data.is_empty() {
+            frames.push_back(Frame::data(data));
+        }
+        if !trailers.is_empty() {
+            frames.push_back(Frame::trailers(trailers));
+        }
+        Self { frames }
+    }
+}
+
+impl HttpBody for FramesBody {
+    type Data = Bytes;
+    type Error = ::tonic::Status;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Poll::Ready(self.frames.pop_front().map(Ok))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.frames.is_empty()
+    }
+}

--- a/crates/cassetter/src/tonic_metadata.rs
+++ b/crates/cassetter/src/tonic_metadata.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use http::HeaderMap;
+
+use crate::Error;
+
+pub(crate) fn grpc_status(headers: &HeaderMap, trailers: &HeaderMap) -> (u32, String) {
+    let status = trailers
+        .get("grpc-status")
+        .or_else(|| headers.get("grpc-status"))
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0);
+    let message = trailers
+        .get("grpc-message")
+        .or_else(|| headers.get("grpc-message"))
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            percent_encoding::percent_decode_str(value)
+                .decode_utf8_lossy()
+                .into_owned()
+        })
+        .unwrap_or_else(|| {
+            if status == 0 {
+                "OK".to_string()
+            } else {
+                String::new()
+            }
+        });
+    (status, message)
+}
+
+pub(crate) fn metadata_to_map(headers: &HeaderMap) -> Result<HashMap<String, Vec<String>>, Error> {
+    let mut metadata = HashMap::new();
+    for (name, value) in headers {
+        if is_transport_header(name.as_str()) {
+            continue;
+        }
+        let value = value.to_str().map_err(|error| {
+            Error::InvalidTransportData(format!("gRPC metadata {name:?} is not text: {error}"))
+        })?;
+        metadata
+            .entry(name.as_str().to_string())
+            .or_insert_with(Vec::new)
+            .push(value.to_string());
+    }
+    Ok(metadata)
+}
+
+pub(crate) fn map_to_headers(metadata: HashMap<String, Vec<String>>) -> Result<HeaderMap, Error> {
+    let mut headers = HeaderMap::new();
+    for (name, values) in metadata {
+        let name = http::header::HeaderName::try_from(name).map_err(|error| {
+            Error::InvalidTransportData(format!("invalid recorded gRPC metadata name: {error}"))
+        })?;
+        for value in values {
+            headers.append(
+                name.clone(),
+                http::HeaderValue::try_from(value).map_err(|error| {
+                    Error::InvalidTransportData(format!(
+                        "invalid recorded gRPC metadata value: {error}"
+                    ))
+                })?,
+            );
+        }
+    }
+    Ok(headers)
+}
+
+pub(crate) fn merge_metadata(
+    target: &mut HashMap<String, Vec<String>>,
+    source: HashMap<String, Vec<String>>,
+) {
+    for (name, values) in source {
+        target.entry(name).or_default().extend(values);
+    }
+}
+
+fn is_transport_header(name: &str) -> bool {
+    matches!(
+        name,
+        "content-type"
+            | "content-length"
+            | "te"
+            | "user-agent"
+            | "grpc-status"
+            | "grpc-message"
+            | "grpc-encoding"
+            | "grpc-accept-encoding"
+            | "grpc-timeout"
+            | "date"
+    )
+}

--- a/crates/cassetter/src/tonic_metadata.rs
+++ b/crates/cassetter/src/tonic_metadata.rs
@@ -4,13 +4,31 @@ use http::HeaderMap;
 
 use crate::Error;
 
-pub(crate) fn grpc_status(headers: &HeaderMap, trailers: &HeaderMap) -> (u32, String) {
-    let status = trailers
+pub(crate) fn grpc_status(
+    http_status: http::StatusCode,
+    headers: &HeaderMap,
+    trailers: &HeaderMap,
+) -> Result<(u32, String), Error> {
+    let status_header = trailers
         .get("grpc-status")
-        .or_else(|| headers.get("grpc-status"))
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(0);
+        .or_else(|| headers.get("grpc-status"));
+    let status = match status_header {
+        Some(value) => {
+            let value = value.to_str().map_err(|error| {
+                Error::InvalidTransportData(format!("gRPC status is not text: {error}"))
+            })?;
+            let status = value.parse::<u32>().map_err(|error| {
+                Error::InvalidTransportData(format!("invalid gRPC status {value:?}: {error}"))
+            })?;
+            if status > 16 {
+                return Err(Error::InvalidTransportData(format!(
+                    "invalid gRPC status code: {status}"
+                )));
+            }
+            status
+        }
+        None => status_from_http(http_status),
+    };
     let message = trailers
         .get("grpc-message")
         .or_else(|| headers.get("grpc-message"))
@@ -20,14 +38,42 @@ pub(crate) fn grpc_status(headers: &HeaderMap, trailers: &HeaderMap) -> (u32, St
                 .decode_utf8_lossy()
                 .into_owned()
         })
-        .unwrap_or_else(|| {
-            if status == 0 {
-                "OK".to_string()
-            } else {
-                String::new()
-            }
-        });
-    (status, message)
+        .unwrap_or_else(|| default_status_message(status_header.is_some(), status, http_status));
+    Ok((status, message))
+}
+
+fn status_from_http(status: http::StatusCode) -> u32 {
+    match status {
+        http::StatusCode::BAD_REQUEST => 13,
+        http::StatusCode::UNAUTHORIZED => 16,
+        http::StatusCode::FORBIDDEN => 7,
+        http::StatusCode::NOT_FOUND => 12,
+        http::StatusCode::TOO_MANY_REQUESTS
+        | http::StatusCode::BAD_GATEWAY
+        | http::StatusCode::SERVICE_UNAVAILABLE
+        | http::StatusCode::GATEWAY_TIMEOUT => 14,
+        _ => 2,
+    }
+}
+
+fn default_status_message(
+    explicit_status: bool,
+    status: u32,
+    http_status: http::StatusCode,
+) -> String {
+    if explicit_status && status == 0 {
+        "OK".to_string()
+    } else if explicit_status {
+        String::new()
+    } else if http_status == http::StatusCode::OK {
+        "protocol error: missing grpc-status trailer, stream was terminated without a final status"
+            .to_string()
+    } else {
+        format!(
+            "grpc-status header missing, mapped from HTTP status code {}",
+            http_status.as_u16()
+        )
+    }
 }
 
 pub(crate) fn metadata_to_map(headers: &HeaderMap) -> Result<HashMap<String, Vec<String>>, Error> {

--- a/crates/cassetter/tests/conformance.rs
+++ b/crates/cassetter/tests/conformance.rs
@@ -1,0 +1,338 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cassetter::{Error, RecordMode, Recorder};
+use cassetter_core::body::compression::DEFAULT_MAX_DECOMPRESSED;
+use cassetter_core::body::process_body;
+use cassetter_core::cassette::Cassette;
+use cassetter_core::interop::{body_from_json, body_to_json, security_config_from_json};
+use cassetter_core::matching::config::MatchConfig;
+use cassetter_core::protocol::http::{BodyContent, HttpRequest};
+use cassetter_core::security::{scrub_grpc_interaction, scrub_interaction, scrub_ws_interaction};
+use reqwest::{Method, Request, Url};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[test]
+fn shared_format_fixtures_parse_and_round_trip() {
+    let root = fixtures("format");
+    let cases: Vec<FormatCase> = read_json(&root.join("cases.json"));
+    for case in cases {
+        let path = root.join(&case.cassette);
+        let cassette = Cassette::load(path.to_str().unwrap()).unwrap_or_else(|error| {
+            panic!("{} failed to load: {error}", case.name);
+        });
+        let expected: Value = read_json(&root.join(&case.expected));
+        assert_eq!(canonical(&cassette), expected, "{}", case.name);
+
+        let directory = tempfile::tempdir().unwrap();
+        let round_trip = directory.path().join(&case.cassette);
+        cassette
+            .save(round_trip.to_str().unwrap(), None, None)
+            .unwrap();
+        let loaded = Cassette::load(round_trip.to_str().unwrap()).unwrap();
+        assert_eq!(canonical(&loaded), expected, "{} round trip", case.name);
+    }
+}
+
+#[test]
+fn shared_invalid_format_fixtures_are_rejected() {
+    let root = fixtures("format/invalid");
+    let cases: Vec<InvalidCase> = read_json(&root.join("cases.json"));
+    for case in cases {
+        let path = root.join(&case.cassette);
+        assert!(
+            Cassette::load(path.to_str().unwrap()).is_err(),
+            "{}",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn shared_matching_fixtures_have_the_expected_results() {
+    let root = fixtures("matching");
+    let source = Cassette::load(root.join("cassette.yaml").to_str().unwrap()).unwrap();
+    let cases: Vec<MatchingCase> = read_json(&root.join("cases.json"));
+    for case in cases {
+        let mut cassette = source.clone();
+        let config = MatchConfig::new(case.match_on, case.ignore_json_paths).unwrap();
+        let statuses = case
+            .requests
+            .iter()
+            .map(|request| {
+                let request = HttpRequest::new(
+                    request["method"].as_str().unwrap().to_string(),
+                    request["uri"].as_str().unwrap().to_string(),
+                    request.get("headers").map(headers),
+                    request.get("body").map(body_from_json),
+                );
+                cassette
+                    .take_match(&request, &config)
+                    .map(|(_, interaction)| interaction.response.status)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(statuses, case.expected_statuses, "{}", case.name);
+    }
+}
+
+#[test]
+fn shared_filtering_fixtures_have_the_expected_results() {
+    let root = fixtures("filtering");
+    let source = Cassette::load(root.join("input.yaml").to_str().unwrap()).unwrap();
+    let cases: Vec<Value> = read_json(&root.join("cases.json"));
+    for case in cases {
+        let config = security_config_from_json(&case).unwrap();
+        let mut cassette = source.clone();
+        cassette.set_interactions(
+            cassette
+                .interactions
+                .iter()
+                .map(|interaction| scrub_interaction(interaction, &config))
+                .collect(),
+        );
+        cassette.set_grpc_interactions(
+            cassette
+                .grpc_interactions
+                .iter()
+                .map(|interaction| scrub_grpc_interaction(interaction, &config))
+                .collect(),
+        );
+        cassette.set_ws_interactions(
+            cassette
+                .ws_interactions
+                .iter()
+                .map(|interaction| scrub_ws_interaction(interaction, &config))
+                .collect(),
+        );
+        let expected: Value = read_json(&root.join(case["expected"].as_str().unwrap()));
+        assert_eq!(canonical(&cassette), expected, "{}", case["name"]);
+    }
+}
+
+#[test]
+fn shared_body_processing_fixtures_have_the_expected_results() {
+    let root = fixtures("body-processing");
+    let cassette = Cassette::load(root.join("cases.yaml").to_str().unwrap()).unwrap();
+    let expected: BTreeMap<String, Value> = read_json(&root.join("expected.json"));
+    for interaction in cassette.interactions {
+        let raw = match interaction.response.body.inner {
+            BodyContent::None => Vec::new(),
+            BodyContent::Binary(value) => value,
+            BodyContent::Text(value) => value.into_bytes(),
+            BodyContent::Json(value) => serde_json::to_vec(&value).unwrap(),
+        };
+        let processed = process_body(
+            raw,
+            first_header(&interaction.response.headers, "content-type"),
+            first_header(&interaction.response.headers, "content-encoding"),
+            DEFAULT_MAX_DECOMPRESSED,
+        )
+        .unwrap();
+        assert_eq!(
+            body_to_json(&processed),
+            expected[&interaction.request.uri],
+            "{}",
+            interaction.request.uri
+        );
+    }
+}
+
+#[tokio::test]
+async fn shared_record_mode_fixtures_have_the_expected_results() {
+    let root = fixtures("record-modes");
+    let cases: Vec<RecordModeCase> = read_json(&root.join("cases.json"));
+    for case in cases {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cassette.yaml");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let base = format!("http://{address}");
+        if case.existing {
+            let mut cassette =
+                Cassette::load(root.join("existing.yaml").to_str().unwrap()).unwrap();
+            cassette.interactions[0].request.uri = format!("{base}/recorded");
+            cassette.save(path.to_str().unwrap(), None, None).unwrap();
+        }
+        let expected_calls = case.expected_base_calls;
+        let server = tokio::spawn(async move {
+            for _ in 0..expected_calls {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let _ = stream.read(&mut request).await.unwrap();
+                stream
+                    .write_all(
+                        b"HTTP/1.1 299 Recorded\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+        let recorder = Recorder::builder(&path)
+            .record_mode(record_mode(&case.mode))
+            .build()
+            .unwrap();
+        let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+        for (uri, outcome) in case.requests.iter().zip(&case.expected_outcomes) {
+            let url = uri.replace("https://example.com", &base);
+            let result = client
+                .execute(Request::new(Method::GET, Url::parse(&url).unwrap()))
+                .await;
+            match outcome.as_str() {
+                "replay" => {
+                    let expected = if uri.ends_with("/recorded") { 201 } else { 299 };
+                    assert_eq!(result.unwrap().status(), expected, "{}", case.name);
+                }
+                "live" => assert_eq!(result.unwrap().status(), 299, "{}", case.name),
+                "no_match" => assert!(
+                    matches!(result, Err(Error::NoMatch { .. })),
+                    "{}",
+                    case.name
+                ),
+                other => panic!("unknown outcome {other}"),
+            }
+        }
+        recorder.finish().await.unwrap();
+        server.await.unwrap();
+
+        match case.expected_file {
+            None => assert!(!path.exists(), "{}", case.name),
+            Some(expected) => {
+                let cassette = Cassette::load(path.to_str().unwrap()).unwrap();
+                let actual = cassette
+                    .interactions
+                    .iter()
+                    .map(|interaction| {
+                        json!({
+                            "uri": interaction.request.uri.replace(&base, "https://example.com"),
+                            "status": interaction.response.status,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(actual, expected, "{}", case.name);
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct FormatCase {
+    name: String,
+    cassette: String,
+    expected: String,
+}
+
+#[derive(Deserialize)]
+struct InvalidCase {
+    name: String,
+    cassette: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RecordModeCase {
+    name: String,
+    mode: String,
+    existing: bool,
+    requests: Vec<String>,
+    expected_outcomes: Vec<String>,
+    expected_base_calls: usize,
+    expected_file: Option<Vec<Value>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MatchingCase {
+    name: String,
+    #[serde(default)]
+    match_on: Option<Vec<String>>,
+    #[serde(default)]
+    ignore_json_paths: Option<Vec<String>>,
+    requests: Vec<Value>,
+    expected_statuses: Vec<Option<u16>>,
+}
+
+fn record_mode(mode: &str) -> RecordMode {
+    match mode {
+        "none" => RecordMode::None,
+        "once" => RecordMode::Once,
+        "new_episodes" => RecordMode::NewEpisodes,
+        "all" => RecordMode::All,
+        "rewrite" => RecordMode::Rewrite,
+        other => panic!("unknown record mode {other}"),
+    }
+}
+
+fn fixtures(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../conformance")
+        .join(name)
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> T {
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+fn headers(value: &Value) -> std::collections::HashMap<String, Vec<String>> {
+    serde_json::from_value(value.clone()).unwrap()
+}
+
+fn canonical(cassette: &Cassette) -> Value {
+    json!({
+        "version": cassette.version,
+        "http": cassette.interactions.iter().map(|interaction| json!({
+            "method": interaction.request.method,
+            "uri": interaction.request.uri,
+            "requestHeaders": sorted_headers(&interaction.request.headers),
+            "requestBody": body_to_json(&interaction.request.body),
+            "status": interaction.response.status,
+            "responseHeaders": sorted_headers(&interaction.response.headers),
+            "responseBody": body_to_json(&interaction.response.body),
+            "recordedAt": interaction.recorded_at,
+        })).collect::<Vec<_>>(),
+        "grpc": cassette.grpc_interactions.iter().map(|interaction| json!({
+            "method": interaction.request.method,
+            "metadata": sorted_headers(&interaction.request.metadata),
+            "requestBody": body_to_json(&interaction.request.body),
+            "statusCode": interaction.response.status_code,
+            "statusMessage": interaction.response.status_message,
+            "responseMetadata": sorted_headers(&interaction.response.metadata),
+            "responseBody": body_to_json(&interaction.response.body),
+            "jsonDebug": interaction.json_debug,
+            "recordedAt": interaction.recorded_at,
+        })).collect::<Vec<_>>(),
+        "ws": cassette.ws_interactions.iter().map(|interaction| json!({
+            "uri": interaction.uri,
+            "headers": sorted_headers(&interaction.headers),
+            "frames": interaction.frames.iter().map(|frame| json!({
+                "direction": frame.direction,
+                "frameType": frame.frame_type,
+                "body": body_to_json(&frame.body),
+                "offsetMs": frame.offset_ms,
+            })).collect::<Vec<_>>(),
+            "recordedAt": interaction.recorded_at,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn sorted_headers(
+    headers: &std::collections::HashMap<String, Vec<String>>,
+) -> BTreeMap<&str, &Vec<String>> {
+    headers
+        .iter()
+        .map(|(name, values)| (name.as_str(), values))
+        .collect()
+}
+
+fn first_header<'a>(
+    headers: &'a std::collections::HashMap<String, Vec<String>>,
+    name: &str,
+) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+        .and_then(|(_, values)| values.first())
+        .map(String::as_str)
+}

--- a/crates/cassetter/tests/conformance.rs
+++ b/crates/cassetter/tests/conformance.rs
@@ -175,6 +175,12 @@ async fn shared_record_mode_fixtures_have_the_expected_results() {
             .build()
             .unwrap();
         let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+        assert_eq!(
+            case.requests.len(),
+            case.expected_outcomes.len(),
+            "{} has mismatched requests and expected outcomes",
+            case.name
+        );
         for (uri, outcome) in case.requests.iter().zip(&case.expected_outcomes) {
             let url = uri.replace("https://example.com", &base);
             let result = client
@@ -195,7 +201,10 @@ async fn shared_record_mode_fixtures_have_the_expected_results() {
             }
         }
         recorder.finish().await.unwrap();
-        server.await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), server)
+            .await
+            .expect("record-mode server did not receive the expected calls")
+            .unwrap();
 
         match case.expected_file {
             None => assert!(!path.exists(), "{}", case.name),

--- a/crates/cassetter/tests/google_grpc.rs
+++ b/crates/cassetter/tests/google_grpc.rs
@@ -41,12 +41,19 @@ async fn google_cloud_tasks_records_and_replays_successes_and_errors() {
         .unwrap_err();
     assert_eq!(error.code(), tonic::Code::NotFound);
     assert_eq!(error.message(), "queue missing");
-    assert_eq!(live_calls.load(Ordering::SeqCst), 2);
+    let error = client
+        .get_queue(request("queues/proxy-error"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::Unavailable);
+    assert!(error.message().contains("HTTP status code 503"));
+    assert_eq!(live_calls.load(Ordering::SeqCst), 3);
     recorder.finish().await.unwrap();
 
     let cassette = std::fs::read_to_string(&path).unwrap();
     assert!(cassette.contains("/google.cloud.tasks.v2.CloudTasks/GetQueue"));
     assert!(cassette.contains("status_code: 5"));
+    assert!(cassette.contains("status_code: 14"));
     assert!(cassette.contains("x-server-header"));
     assert!(cassette.contains("x-server-trailer"));
     assert!(!cassette.contains("Bearer secret"));
@@ -74,6 +81,12 @@ async fn google_cloud_tasks_records_and_replays_successes_and_errors() {
     assert_eq!(error.code(), tonic::Code::NotFound);
     assert_eq!(error.message(), "queue missing");
     assert!(error.metadata().get("x-server-trailer").is_some());
+    let error = client
+        .get_queue(request("queues/proxy-error"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::Unavailable);
+    assert!(error.message().contains("HTTP status code 503"));
 
     let mismatch = client.get_queue(request("queues/other")).await.unwrap_err();
     assert!(mismatch
@@ -112,15 +125,17 @@ impl Service<Request<tonic::body::Body>> for GoogleTransport {
 
     fn call(&mut self, _request: Request<tonic::body::Body>) -> Self::Future {
         let call = self.calls.fetch_add(1, Ordering::SeqCst);
-        if call == 0 {
-            let payload = Queue {
-                name: "queues/one".to_string(),
-                ..Queue::default()
+        match call {
+            0 => {
+                let payload = Queue {
+                    name: "queues/one".to_string(),
+                    ..Queue::default()
+                }
+                .encode_to_vec();
+                ready(Ok(grpc_response(payload, 0, "", true)))
             }
-            .encode_to_vec();
-            ready(Ok(grpc_response(payload, 0, "", true)))
-        } else {
-            ready(Ok(grpc_response(Vec::new(), 5, "queue%20missing", true)))
+            1 => ready(Ok(grpc_response(Vec::new(), 5, "queue%20missing", true))),
+            _ => ready(Ok(http_error_response())),
         }
     }
 }
@@ -143,6 +158,13 @@ impl Service<Request<tonic::body::Body>> for OfflineTransport {
         self.calls.fetch_add(1, Ordering::SeqCst);
         panic!("offline replay reached the live Google transport")
     }
+}
+
+fn http_error_response() -> Response<tonic::body::Body> {
+    Response::builder()
+        .status(503)
+        .body(tonic::body::Body::empty())
+        .unwrap()
 }
 
 fn grpc_response(

--- a/crates/cassetter/tests/google_grpc.rs
+++ b/crates/cassetter/tests/google_grpc.rs
@@ -1,0 +1,202 @@
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::future::{ready, Ready};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use cassetter::{RecordMode, Recorder};
+use googleapis_tonic_google_cloud_tasks_v2::google::cloud::tasks::v2::cloud_tasks_client::CloudTasksClient;
+use googleapis_tonic_google_cloud_tasks_v2::google::cloud::tasks::v2::{GetQueueRequest, Queue};
+use http::{HeaderMap, Request, Response};
+use http_body::{Body, Frame};
+use prost::Message;
+use tower_service::Service;
+
+#[tokio::test]
+async fn google_cloud_tasks_records_and_replays_successes_and_errors() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("cloud-tasks.yaml");
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let transport = GoogleTransport {
+        calls: live_calls.clone(),
+    };
+    let mut client = CloudTasksClient::new(cassetter::tonic::GrpcService::new(
+        transport,
+        recorder.clone(),
+    ));
+
+    let response = client.get_queue(request("queues/one")).await.unwrap();
+    assert!(response.metadata().get("x-server-header").is_some());
+    assert_eq!(response.into_inner().name, "queues/one");
+    let error = client
+        .get_queue(request("queues/missing"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::NotFound);
+    assert_eq!(error.message(), "queue missing");
+    assert_eq!(live_calls.load(Ordering::SeqCst), 2);
+    recorder.finish().await.unwrap();
+
+    let cassette = std::fs::read_to_string(&path).unwrap();
+    assert!(cassette.contains("/google.cloud.tasks.v2.CloudTasks/GetQueue"));
+    assert!(cassette.contains("status_code: 5"));
+    assert!(cassette.contains("x-server-header"));
+    assert!(cassette.contains("x-server-trailer"));
+    assert!(!cassette.contains("Bearer secret"));
+    assert!(!cassette.contains("google-api-key"));
+
+    let offline_calls = Arc::new(AtomicUsize::new(0));
+    let replay = Recorder::builder(&path)
+        .record_mode(RecordMode::None)
+        .build()
+        .unwrap();
+    let mut client = CloudTasksClient::new(cassetter::tonic::GrpcService::new(
+        OfflineTransport {
+            calls: offline_calls.clone(),
+        },
+        replay.clone(),
+    ));
+
+    let response = client.get_queue(request("queues/one")).await.unwrap();
+    assert!(response.metadata().get("x-server-header").is_some());
+    assert_eq!(response.into_inner().name, "queues/one");
+    let error = client
+        .get_queue(request("queues/missing"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::NotFound);
+    assert_eq!(error.message(), "queue missing");
+    assert!(error.metadata().get("x-server-trailer").is_some());
+
+    let mismatch = client.get_queue(request("queues/other")).await.unwrap_err();
+    assert!(mismatch
+        .message()
+        .contains("no matching gRPC cassette interaction"));
+    assert_eq!(offline_calls.load(Ordering::SeqCst), 0);
+    replay.finish().await.unwrap();
+}
+
+fn request(name: &str) -> tonic::Request<GetQueueRequest> {
+    let mut request = tonic::Request::new(GetQueueRequest {
+        name: name.to_string(),
+    });
+    request
+        .metadata_mut()
+        .insert("authorization", "Bearer secret".parse().unwrap());
+    request
+        .metadata_mut()
+        .insert("x-goog-api-key", "google-api-key".parse().unwrap());
+    request
+}
+
+#[derive(Clone)]
+struct GoogleTransport {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Service<Request<tonic::body::Body>> for GoogleTransport {
+    type Response = Response<tonic::body::Body>;
+    type Error = Infallible;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _request: Request<tonic::body::Body>) -> Self::Future {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if call == 0 {
+            let payload = Queue {
+                name: "queues/one".to_string(),
+                ..Queue::default()
+            }
+            .encode_to_vec();
+            ready(Ok(grpc_response(payload, 0, "", true)))
+        } else {
+            ready(Ok(grpc_response(Vec::new(), 5, "queue%20missing", true)))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct OfflineTransport {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Service<Request<tonic::body::Body>> for OfflineTransport {
+    type Response = Response<tonic::body::Body>;
+    type Error = Infallible;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _request: Request<tonic::body::Body>) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        panic!("offline replay reached the live Google transport")
+    }
+}
+
+fn grpc_response(
+    payload: Vec<u8>,
+    status: u32,
+    message: &str,
+    with_metadata: bool,
+) -> Response<tonic::body::Body> {
+    let mut framed = Vec::new();
+    if !payload.is_empty() {
+        framed.push(0);
+        framed.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        framed.extend_from_slice(&payload);
+    }
+    let mut trailers = HeaderMap::new();
+    trailers.insert("grpc-status", status.to_string().parse().unwrap());
+    trailers.insert("grpc-message", message.parse().unwrap());
+    if with_metadata {
+        trailers.insert("x-server-trailer", "present".parse().unwrap());
+    }
+    Response::builder()
+        .status(200)
+        .header("content-type", "application/grpc")
+        .header("x-server-header", "present")
+        .body(tonic::body::Body::new(TestBody::new(
+            Bytes::from(framed),
+            trailers,
+        )))
+        .unwrap()
+}
+
+struct TestBody {
+    frames: VecDeque<Frame<Bytes>>,
+}
+
+impl TestBody {
+    fn new(data: Bytes, trailers: HeaderMap) -> Self {
+        let mut frames = VecDeque::new();
+        if !data.is_empty() {
+            frames.push_back(Frame::data(data));
+        }
+        frames.push_back(Frame::trailers(trailers));
+        Self { frames }
+    }
+}
+
+impl Body for TestBody {
+    type Data = Bytes;
+    type Error = tonic::Status;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Poll::Ready(self.frames.pop_front().map(Ok))
+    }
+}

--- a/crates/cassetter/tests/http.rs
+++ b/crates/cassetter/tests/http.rs
@@ -27,7 +27,7 @@ async fn records_and_replays_http_responses_and_errors_offline() {
 
     let recorder = Recorder::builder(&path)
         .record_mode(RecordMode::All)
-        .match_on(["method", "uri", "json_body"])
+        .match_on(["method", "uri", "headers", "json_body"])
         .unwrap()
         .build()
         .unwrap();
@@ -53,7 +53,7 @@ async fn records_and_replays_http_responses_and_errors_offline() {
 
     let replay = Recorder::builder(&path)
         .record_mode(RecordMode::None)
-        .match_on(["method", "uri", "json_body"])
+        .match_on(["method", "uri", "headers", "json_body"])
         .unwrap()
         .build()
         .unwrap();
@@ -86,6 +86,102 @@ async fn records_and_replays_http_responses_and_errors_offline() {
             ..
         }
     ));
+    replay.finish().await.unwrap();
+}
+
+#[tokio::test]
+async fn skips_opaque_headers_that_cassettes_cannot_represent() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("opaque.yaml");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 4096];
+        let _ = stream.read(&mut request).await.unwrap();
+        let mut response = b"HTTP/1.1 200 OK\r\nx-opaque: ".to_vec();
+        response.extend_from_slice(&[0xff]);
+        response.extend_from_slice(b"\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok");
+        stream.write_all(&response).await.unwrap();
+    });
+    let url = Url::parse(&format!("http://{address}/opaque")).unwrap();
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    assert_eq!(
+        client
+            .execute(Request::new(Method::GET, url.clone()))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap(),
+        "ok"
+    );
+    recorder.finish().await.unwrap();
+    server.await.unwrap();
+    assert!(!std::fs::read_to_string(&path).unwrap().contains("x-opaque"));
+
+    let replay = Recorder::builder(path)
+        .record_mode(RecordMode::None)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), replay.clone());
+    assert_eq!(
+        client
+            .execute(Request::new(Method::GET, url))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap(),
+        "ok"
+    );
+    replay.finish().await.unwrap();
+}
+
+#[tokio::test]
+async fn preserves_content_length_for_bodyless_responses() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("head.yaml");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 4096];
+        let _ = stream.read(&mut request).await.unwrap();
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 123\r\nconnection: close\r\n\r\n")
+            .await
+            .unwrap();
+    });
+    let url = Url::parse(&format!("http://{address}/head")).unwrap();
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    let response = client
+        .execute(Request::new(Method::HEAD, url.clone()))
+        .await
+        .unwrap();
+    assert_eq!(response.headers()["content-length"], "123");
+    recorder.finish().await.unwrap();
+    server.await.unwrap();
+
+    let replay = Recorder::builder(path)
+        .record_mode(RecordMode::None)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), replay.clone());
+    let response = client
+        .execute(Request::new(Method::HEAD, url))
+        .await
+        .unwrap();
+    assert_eq!(response.headers()["content-length"], "123");
+    assert!(response.bytes().await.unwrap().is_empty());
     replay.finish().await.unwrap();
 }
 
@@ -221,6 +317,10 @@ fn request(url: Url, value: &str, credential: &str) -> Request {
     request
         .headers_mut()
         .insert("x-goog-api-key", "google-api-key".parse().unwrap());
-    *request.body_mut() = Some(reqwest::Body::from(format!(r#"{{"name":"{value}"}}"#)));
+    let body = format!(r#"{{ "name": "{value}" }}"#);
+    request
+        .headers_mut()
+        .insert("content-length", body.len().into());
+    *request.body_mut() = Some(reqwest::Body::from(body));
     request
 }

--- a/crates/cassetter/tests/http.rs
+++ b/crates/cassetter/tests/http.rs
@@ -1,0 +1,226 @@
+use cassetter::{Error, RecordMode, Recorder};
+use reqwest::{Method, Request, Url};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn records_and_replays_http_responses_and_errors_offline() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("google-http.yaml");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        for (status, body) in [
+            ("200 OK", r#"{"name":"queues/one"}"#),
+            ("503 Unavailable", r#"{"error":"retry"}"#),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\nx-request-id: recorded\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .match_on(["method", "uri", "json_body"])
+        .unwrap()
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    let url = Url::parse(&format!("http://{address}/v2/projects/test/queues")).unwrap();
+
+    let first = request(url.clone(), "one", "secret");
+    let response = client.execute(first).await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.bytes().await.unwrap(), r#"{"name":"queues/one"}"#);
+
+    let second = request(url.clone(), "error", "secret");
+    let response = client.execute(second).await.unwrap();
+    assert_eq!(response.status(), 503);
+    assert_eq!(response.bytes().await.unwrap(), r#"{"error":"retry"}"#);
+    recorder.finish().await.unwrap();
+    server.await.unwrap();
+
+    let cassette = std::fs::read_to_string(&path).unwrap();
+    assert!(cassette.contains("x-request-id"));
+    assert!(!cassette.contains("Bearer secret"));
+    assert!(!cassette.contains("google-api-key"));
+
+    let replay = Recorder::builder(&path)
+        .record_mode(RecordMode::None)
+        .match_on(["method", "uri", "json_body"])
+        .unwrap()
+        .build()
+        .unwrap();
+    let offline = cassetter::reqwest::Client::new(reqwest::Client::new(), replay.clone());
+    assert_eq!(
+        offline
+            .execute(request(url.clone(), "one", "secret"))
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    assert_eq!(
+        offline
+            .execute(request(url.clone(), "error", "secret"))
+            .await
+            .unwrap()
+            .status(),
+        503
+    );
+
+    let error = offline
+        .execute(request(url, "different", "secret"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::NoMatch {
+            protocol: "HTTP",
+            ..
+        }
+    ));
+    replay.finish().await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_recorders_keep_cassettes_isolated() {
+    let directory = tempfile::tempdir().unwrap();
+    let (first_url, first_server) = one_response_server("first").await;
+    let (second_url, second_server) = one_response_server("second").await;
+    let first_path = directory.path().join("first.yaml");
+    let second_path = directory.path().join("second.yaml");
+    let first_recorder = Recorder::builder(&first_path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let second_recorder = Recorder::builder(&second_path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let first = cassetter::reqwest::Client::new(reqwest::Client::new(), first_recorder.clone());
+    let second = cassetter::reqwest::Client::new(reqwest::Client::new(), second_recorder.clone());
+
+    let (first_response, second_response) = tokio::join!(
+        first.execute(Request::new(Method::GET, first_url)),
+        second.execute(Request::new(Method::GET, second_url)),
+    );
+    assert_eq!(first_response.unwrap().text().await.unwrap(), "first");
+    assert_eq!(second_response.unwrap().text().await.unwrap(), "second");
+    first_recorder.finish().await.unwrap();
+    second_recorder.finish().await.unwrap();
+    first_server.await.unwrap();
+    second_server.await.unwrap();
+
+    let first_cassette = std::fs::read_to_string(first_path).unwrap();
+    let second_cassette = std::fs::read_to_string(second_path).unwrap();
+    assert!(first_cassette.contains("first"));
+    assert!(!first_cassette.contains("second"));
+    assert!(second_cassette.contains("second"));
+    assert!(!second_cassette.contains("first"));
+}
+
+#[tokio::test]
+async fn finalization_reports_a_save_error() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("cassette.yaml");
+    std::fs::create_dir(&path).unwrap();
+    let (url, server) = one_response_server("response").await;
+    let recorder = Recorder::builder(path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+
+    let error = client
+        .execute(Request::new(Method::GET, url))
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::Recording(_)));
+    let error = recorder.finish().await.unwrap_err();
+    assert!(matches!(error, Error::Recording(_)));
+    let error = recorder.finish().await.unwrap_err();
+    assert!(matches!(error, Error::Recording(_)));
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn finalization_reports_a_cancelled_recording() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("cancelled.yaml");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        accepted_tx.send(()).unwrap();
+        let _ = release_rx.await;
+        drop(stream);
+    });
+    let recorder = Recorder::builder(path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    let task = tokio::spawn(async move {
+        client
+            .execute(Request::new(
+                Method::GET,
+                Url::parse(&format!("http://{address}/hang")).unwrap(),
+            ))
+            .await
+    });
+    accepted_rx.await.unwrap();
+    task.abort();
+    let _ = task.await;
+
+    let error = recorder.finish().await.unwrap_err();
+    assert!(
+        error.to_string().contains("incomplete cassette recording"),
+        "{error}"
+    );
+    release_tx.send(()).unwrap();
+    server.await.unwrap();
+}
+
+async fn one_response_server(body: &'static str) -> (Url, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 4096];
+        let _ = stream.read(&mut request).await.unwrap();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    });
+    (
+        Url::parse(&format!("http://{address}/value")).unwrap(),
+        server,
+    )
+}
+
+fn request(url: Url, value: &str, credential: &str) -> Request {
+    let mut request = Request::new(Method::POST, url);
+    request
+        .headers_mut()
+        .insert("content-type", "application/json".parse().unwrap());
+    request.headers_mut().insert(
+        "authorization",
+        format!("Bearer {credential}").parse().unwrap(),
+    );
+    request
+        .headers_mut()
+        .insert("x-goog-api-key", "google-api-key".parse().unwrap());
+    *request.body_mut() = Some(reqwest::Body::from(format!(r#"{{"name":"{value}"}}"#)));
+    request
+}

--- a/go/testdata/conformance/README.md
+++ b/go/testdata/conformance/README.md
@@ -60,6 +60,7 @@ A format case passes when an SDK parses its cassette into the corresponding cano
 | Python | `tests/test_conformance.py`, `tests/test_*_conformance.py` |
 | Node | `ts/tests/*conformance.test.ts` |
 | Go | `go/conformance_test.go`, `go/*_conformance_test.go` |
+| Rust | `crates/cassetter/tests/conformance.rs` |
 
 Each SDK reads the shared manifests. Add a case once and every implementation receives it.
 The nested Go module includes a synchronized copy under `go/testdata/conformance/`.
@@ -74,6 +75,7 @@ $ cp -R conformance go/testdata/conformance
 $ uv run pytest tests/test_conformance.py tests/test_*_conformance.py
 $ (cd ts && npm test -- --run tests/conformance.test.ts tests/behavior-conformance.test.ts tests/record-modes-conformance.test.ts)
 $ (cd go && go test ./...)
+$ cargo test -p cassetter --test conformance
 ```
 
 Add the input and expected result to the appropriate directory.


### PR DESCRIPTION
Adds a publishable `cassetter` Rust crate with explicit `reqwest` and unary `tonic` transport injection, shared record modes, request-body matching, security filtering, deterministic concurrent recording, and explicit finalization errors. Adds runnable examples, shared conformance coverage, and a generated Google Cloud Tasks client test that verifies success and error replay without reaching its live transport. Updates CI, MSRV validation, and coordinated crates.io publishing.

Closes #111

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.