### PR TITLE
Add a configurable default cassette file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ with recorder.use_cassette("openai.yaml", record_mode="all"):
     ...
 ```
 
-It takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against. The object is frozen and callable, so `recorder("openai.yaml")` works too.
+It takes every option `use_cassette()` takes, plus `cassette_library_dir` - the directory cassette names are resolved against - and `cassette_extension` (`yaml`, `yml`, or `toml`) for names that lack a supported cassette suffix (`.yaml`, `.yml`, or `.toml`). The object is frozen and callable, so `recorder("openai.yaml")` works too.
 
 The `vcr_config` fixture accepts a `Cassetter`, so one object can configure both the pytest suite and direct `use_cassette()` calls:
 
@@ -177,7 +177,7 @@ These add to the built-in lists rather than standing in for them, so naming one 
 
 ## Cassette format
 
-Cassettes can be stored as **YAML** (default) or **TOML**. The format is detected by file extension (`.yaml` / `.yml` for YAML, `.toml` for TOML).
+Cassettes can be stored as **YAML** (default) or **TOML**. The format is detected by file extension (`.yaml` / `.yml` for YAML, `.toml` for TOML). Names that lack a supported cassette suffix (`.yaml`, `.yml`, or `.toml`) pick up `cassette_extension` on [`Cassetter`](#with-a-reusable-configuration) (default `yaml`).
 
 ### YAML (default)
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -219,7 +219,7 @@ When `record_mode=none` and a cassette file doesn't exist, the fixture creates a
 
 ## 7. Configuration object
 
-`Cassetter` is a frozen dataclass holding the options shared by a group of cassettes. It exposes `use_cassette(name, **overrides)`, and `cassette_library_dir` - the directory cassette names are resolved against.
+`Cassetter` is a frozen dataclass holding the options shared by a group of cassettes. It exposes `use_cassette(name, **overrides)`, `cassette_library_dir` - the directory cassette names are resolved against - and `cassette_extension` (`yaml`, `yml`, or `toml`) for names that have no cassette suffix.
 
 ```python
 recorder = Cassetter(cassette_library_dir="tests/cassettes", record_mode="none")

--- a/crates/cassetter-core/src/cassette/mod.rs
+++ b/crates/cassetter-core/src/cassette/mod.rs
@@ -3,7 +3,7 @@ pub mod format_toml;
 pub mod index;
 pub mod ordering;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::matching::config::MatchConfig;
 use crate::protocol::grpc::{GrpcInteraction, GrpcRequest};
@@ -378,9 +378,90 @@ impl Cassette {
     }
 }
 
+const CASSETTE_EXTENSIONS: [&str; 3] = ["toml", "yaml", "yml"];
+
 /// Whether this path names a TOML cassette rather than a YAML one.
 pub fn is_toml(path: &str) -> bool {
     Path::new(path)
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+}
+
+/// Canonical cassette suffix: `yaml`, `yml`, or `toml`.
+pub fn normalize_cassette_extension(value: &str) -> Result<String> {
+    let extension = value
+        .strip_prefix('.')
+        .unwrap_or(value)
+        .to_ascii_lowercase();
+    if CASSETTE_EXTENSIONS.contains(&extension.as_str()) {
+        Ok(extension)
+    } else {
+        Err(CassetteError::Value(format!(
+            "cassette_extension must be one of {}, got {value:?}",
+            CASSETTE_EXTENSIONS.join(", ")
+        )))
+    }
+}
+
+/// Append `extension` when `path` is not already a cassette file.
+///
+/// Only `.yaml`, `.yml`, and `.toml` count as a format suffix, so names that
+/// contain other dots still get one.
+pub fn apply_cassette_extension(path: impl AsRef<Path>, extension: &str) -> PathBuf {
+    let path = path.as_ref();
+    let existing = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if CASSETTE_EXTENSIONS.contains(&existing.as_str()) {
+        return path.to_path_buf();
+    }
+    let mut os_string = path.as_os_str().to_os_string();
+    os_string.push(".");
+    os_string.push(extension);
+    PathBuf::from(os_string)
+}
+
+#[cfg(test)]
+mod extension_tests {
+    use super::{apply_cassette_extension, normalize_cassette_extension};
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalize_accepts_aliases() {
+        assert_eq!(normalize_cassette_extension("yaml").unwrap(), "yaml");
+        assert_eq!(normalize_cassette_extension(".YML").unwrap(), "yml");
+        assert_eq!(normalize_cassette_extension("TOML").unwrap(), "toml");
+    }
+
+    #[test]
+    fn normalize_rejects_unknown_values() {
+        let error = normalize_cassette_extension("json").unwrap_err();
+        assert!(error.to_string().contains("cassette_extension"));
+    }
+
+    #[test]
+    fn apply_appends_when_suffix_is_missing() {
+        assert_eq!(
+            apply_cassette_extension("openai", "toml"),
+            PathBuf::from("openai.toml")
+        );
+    }
+
+    #[test]
+    fn apply_keeps_an_explicit_cassette_suffix() {
+        assert_eq!(
+            apply_cassette_extension("openai.yaml", "toml"),
+            PathBuf::from("openai.yaml")
+        );
+    }
+
+    #[test]
+    fn apply_appends_when_the_name_contains_other_dots() {
+        assert_eq!(
+            apply_cassette_extension("test_func[gpt-5.4]", "yaml"),
+            PathBuf::from("test_func[gpt-5.4].yaml")
+        );
+    }
 }

--- a/crates/cassetter/README.md
+++ b/crates/cassetter/README.md
@@ -79,6 +79,23 @@ must not consume each other's interactions.
 Always call `Recorder::finish`. It saves an empty replacement cassette when
 needed and reports persistence failures or calls cancelled while recording.
 
+## Cassette format
+
+YAML is the default. Use a `.toml` path for TOML, or set the suffix for names
+that do not already end in `.yaml`, `.yml`, or `.toml`:
+
+```rust,no_run
+use cassetter::Recorder;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let recorder = Recorder::builder("tests/cassettes/users")
+    .cassette_extension("toml")?
+    .build()?;
+# let _ = recorder;
+# Ok(())
+# }
+```
+
 ## Current limits
 
 - HTTP request and response bodies are buffered in memory.

--- a/crates/cassetter/src/config.rs
+++ b/crates/cassetter/src/config.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use cassetter_core::cassette::{apply_cassette_extension, normalize_cassette_extension};
 use cassetter_core::matching::config::MatchConfig;
 pub use cassetter_core::recording::RecordMode;
 use cassetter_core::security::SecurityConfig;
@@ -10,6 +11,7 @@ use crate::{Error, Recorder, Result};
 #[derive(Debug)]
 pub struct RecorderBuilder {
     pub(crate) path: PathBuf,
+    pub(crate) cassette_extension: String,
     pub(crate) mode: RecordMode,
     pub(crate) matching: MatchConfig,
     pub(crate) security: SecurityConfig,
@@ -19,10 +21,17 @@ impl RecorderBuilder {
     pub(crate) fn new(path: PathBuf) -> Self {
         Self {
             path,
+            cassette_extension: "yaml".to_string(),
             mode: RecordMode::Once,
             matching: MatchConfig::default(),
             security: SecurityConfig::default(),
         }
+    }
+
+    /// Suffix used when the cassette path is not already `.yaml`, `.yml`, or `.toml`.
+    pub fn cassette_extension(mut self, extension: impl Into<String>) -> Result<Self> {
+        self.cassette_extension = normalize_cassette_extension(&extension.into())?;
+        Ok(self)
     }
 
     /// Select the record mode.
@@ -91,7 +100,8 @@ impl RecorderBuilder {
     }
 
     /// Load or initialize the cassette.
-    pub fn build(self) -> Result<Recorder> {
+    pub fn build(mut self) -> Result<Recorder> {
+        self.path = apply_cassette_extension(&self.path, &self.cassette_extension);
         Recorder::from_builder(self)
     }
 }
@@ -116,4 +126,61 @@ pub(crate) fn path_text(path: &Path) -> Result<&str> {
     path.to_str().ok_or_else(|| {
         Error::InvalidTransportData(format!("cassette path is not valid UTF-8: {path:?}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cassetter_core::cassette::Cassette;
+
+    #[test]
+    fn default_extension_loads_yaml_for_an_extensionless_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let yaml = directory.path().join("users.yaml");
+        Cassette::new()
+            .save(yaml.to_str().unwrap(), None, None)
+            .unwrap();
+        Recorder::builder(directory.path().join("users"))
+            .record_mode(RecordMode::None)
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn cassette_extension_selects_toml() {
+        let directory = tempfile::tempdir().unwrap();
+        let toml = directory.path().join("users.toml");
+        Cassette::new()
+            .save(toml.to_str().unwrap(), None, None)
+            .unwrap();
+        Recorder::builder(directory.path().join("users"))
+            .cassette_extension("toml")
+            .unwrap()
+            .record_mode(RecordMode::None)
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn cassette_extension_keeps_an_explicit_suffix() {
+        let directory = tempfile::tempdir().unwrap();
+        let yaml = directory.path().join("users.yaml");
+        Cassette::new()
+            .save(yaml.to_str().unwrap(), None, None)
+            .unwrap();
+        Recorder::builder(&yaml)
+            .cassette_extension("toml")
+            .unwrap()
+            .record_mode(RecordMode::None)
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn cassette_extension_rejects_unknown_values() {
+        let error = Recorder::builder("users")
+            .cassette_extension("json")
+            .unwrap_err();
+        assert!(error.to_string().contains("cassette_extension"));
+    }
 }

--- a/docs/tutorial/configuration.md
+++ b/docs/tutorial/configuration.md
@@ -19,7 +19,7 @@ with recorder.use_cassette("anthropic.yaml"):
     ...
 ```
 
-It accepts every option `use_cassette()` accepts, plus `cassette_library_dir`. Anything you leave out keeps its default.
+It accepts every option `use_cassette()` accepts, plus `cassette_library_dir` and `cassette_extension`. Anything you leave out keeps its default.
 
 The object is callable, so `recorder("openai.yaml")` is the same as `recorder.use_cassette("openai.yaml")`.
 
@@ -35,6 +35,19 @@ with recorder.use_cassette("openai.yaml"):  # src/evals/cassettes/openai.yaml
 ```
 
 Names can include subdirectories, and an absolute path is used as is. Without `cassette_library_dir`, the name is the path, exactly like `use_cassette()`.
+
+## Cassette format
+
+`cassette_extension` is the suffix added when a cassette name lacks a supported cassette suffix (`.yaml`, `.yml`, or `.toml`). The default is `yaml`. Use `yml` or `toml` to change what unmarked pytest tests and names like `"openai"` or `"openai.v1"` write:
+
+```python
+recorder = Cassetter(cassette_library_dir="tests/cassettes", cassette_extension="toml")
+
+with recorder.use_cassette("openai"):  # tests/cassettes/openai.toml
+    ...
+```
+
+A name that already ends in `.yaml`, `.yml`, or `.toml` keeps that suffix, so one configuration can still mix formats.
 
 ## Override one cassette
 

--- a/docs/tutorial/formats.md
+++ b/docs/tutorial/formats.md
@@ -2,6 +2,26 @@
 
 Cassettes can be stored as **YAML** (the default) or **TOML**. The format is detected from the file extension: `.yaml` and `.yml` for YAML, `.toml` for TOML.
 
+When a cassette name has no extension, Cassetter appends the configured default (Python `cassette_extension`, Rust `cassette_extension()`, Go `WithCassetteExtension`, JS/TS `cassetteExtension`). The default is `yaml`. A name that already ends in `.yaml`, `.yml`, or `.toml` keeps that suffix.
+
+```python
+from cassetter import Cassetter
+
+recorder = Cassetter(cassette_extension="toml")
+```
+
+```rust
+Recorder::builder("tests/cassettes/users").cassette_extension("toml")?
+```
+
+```go
+cassetter.WithCassetteExtension("toml")
+```
+
+```ts
+await useCassette("users", { cassetteExtension: "toml" }, async () => { ... });
+```
+
 ## YAML
 
 The default, and the most readable. JSON bodies are stored as structured YAML:

--- a/docs/tutorial/pytest.md
+++ b/docs/tutorial/pytest.md
@@ -28,6 +28,8 @@ For a test `test_api_call` in `tests/test_users.py`, that is `tests/cassettes/te
 
 For tests inside a class, the class name is included: `TestUsers.test_api_call.yaml`.
 
+`.yaml` is the default cassette suffix. Set `cassette_extension` in `vcr_config` to `yml` or `toml` to change it, for example `vcr_config["cassette_extension"] = "toml"` writes `test_api_call.toml` instead.
+
 ## Record the cassette
 
 By default the plugin runs in the `none` record mode: replay only, never touch the network. To record cassettes for the first time, pass `--record-mode`:
@@ -101,6 +103,7 @@ The supported keys are the same options accepted by `use_cassette()`:
 | `filter_replacement` | Replacement string for filtered values |
 | `cassette_dir` | Cassette directory, relative to the test file |
 | `cassette_library_dir` | Cassette directory, used as is |
+| `cassette_extension` | Suffix for generated cassette names (`yaml` by default; `yml` or `toml` via `vcr_config`) |
 | `intercept` | Libraries to intercept |
 | `max_age` | Cassette expiry, e.g. `"30d"` |
 | `on_expiry` | What to do with expired cassettes |

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added `WithCassetteExtension` so cassette paths without `.yaml`, `.yml`, or `.toml` pick a default format.
+
 ## 0.1.0 - 2026-09-04
 
 This is the first release of the Go SDK.

--- a/go/README.md
+++ b/go/README.md
@@ -65,7 +65,16 @@ It only replays when the cassette already exists.
 | `RecordModeAll` | Record every request and replace existing interactions. |
 | `RecordModeRewrite` | Remove the cassette first, then record every request. |
 
-Use a `.toml` path to store HTTP cassettes as TOML. Other extensions use YAML.
+Use a `.toml` path to store HTTP cassettes as TOML. Other cassette extensions use YAML.
+Names without `.yaml`, `.yml`, or `.toml` pick up `WithCassetteExtension` (default `yaml`):
+
+```go
+cassetter.NewTransport(
+    http.DefaultTransport,
+    cassetter.WithPath("tests/cassettes/openai"),
+    cassetter.WithCassetteExtension("toml"),
+)
+```
 
 ## Record and replay gRPC
 

--- a/go/cassette_extension_test.go
+++ b/go/cassette_extension_test.go
@@ -1,0 +1,110 @@
+package cassetter_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Kludex/cassetter/go"
+)
+
+const usersURI = "https://example.com/users"
+
+func TestTransportAppliesDefaultCassetteExtension(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	saveMatchingCassette(t, filepath.Join(directory, "users.yaml"), cassetter.HTTPRequest{
+		Method: http.MethodGet,
+		URI:    usersURI,
+	})
+	assertReplaysUsers(t, cassetter.WithPath(filepath.Join(directory, "users")))
+}
+
+func TestTransportCassetteExtensionSelectsTOML(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	stem := filepath.Join(directory, "users")
+	tomlPath := stem + ".toml"
+	transport := cassetter.NewTransport(
+		roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        make(http.Header),
+				Body:          io.NopCloser(strings.NewReader("ok")),
+				ContentLength: 2,
+				Request:       request,
+			}, nil
+		}),
+		cassetter.WithPath(stem),
+		cassetter.WithCassetteExtension("toml"),
+		cassetter.WithRecordMode(cassetter.RecordModeAll),
+	)
+	client := &http.Client{Transport: transport}
+	response, err := client.Get("https://example.com/users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cassetter.Load(tomlPath); err != nil {
+		t.Fatalf("expected toml cassette: %v", err)
+	}
+}
+
+func TestTransportCassetteExtensionKeepsExplicitSuffix(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	yamlPath := filepath.Join(directory, "users.yaml")
+	saveMatchingCassette(t, yamlPath, cassetter.HTTPRequest{
+		Method: http.MethodGet,
+		URI:    usersURI,
+	})
+	assertReplaysUsers(t,
+		cassetter.WithPath(yamlPath),
+		cassetter.WithCassetteExtension("toml"),
+	)
+}
+
+func TestTransportCassetteExtensionRejectsUnknownValues(t *testing.T) {
+	t.Parallel()
+	transport := cassetter.NewTransport(
+		nil,
+		cassetter.WithPath(filepath.Join(t.TempDir(), "users")),
+		cassetter.WithCassetteExtension("json"),
+	)
+	if err := transport.Initialize(); err == nil || !strings.Contains(err.Error(), "cassette_extension") {
+		t.Fatalf("initialization error = %v", err)
+	}
+}
+
+func assertReplaysUsers(t *testing.T, options ...cassetter.Option) {
+	t.Helper()
+	options = append([]cassetter.Option{cassetter.WithRecordMode(cassetter.RecordModeNone)}, options...)
+	client := &http.Client{Transport: cassetter.NewTransport(
+		roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("unexpected live request")
+		}),
+		options...,
+	)}
+	response, err := client.Get(usersURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "matched" {
+		t.Fatalf("replay body = %q", content)
+	}
+}

--- a/go/format.go
+++ b/go/format.go
@@ -1,10 +1,31 @@
 package cassetter
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
 
 func isTOML(path string) bool {
 	return strings.EqualFold(filepath.Ext(path), ".toml")
+}
+
+func normalizeCassetteExtension(value string) (string, error) {
+	extension := strings.ToLower(strings.TrimPrefix(value, "."))
+	switch extension {
+	case "yaml", "yml", "toml":
+		return extension, nil
+	default:
+		return "", fmt.Errorf("cassetter: cassette_extension must be one of toml, yaml, yml, got %q", value)
+	}
+}
+
+func applyCassetteExtension(path string, extension string) string {
+	existing := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+	switch existing {
+	case "yaml", "yml", "toml":
+		return path
+	default:
+		return path + "." + extension
+	}
 }

--- a/go/options.go
+++ b/go/options.go
@@ -55,24 +55,34 @@ func (option optionFunc) apply(config *transportConfig) {
 }
 
 type transportConfig struct {
-	path            string
-	mode            RecordMode
-	security        SecurityConfig
-	matchers        []Matcher
-	ignoreJSONPaths []string
-	uriNormalizer   func(string) string
-	maxAge          *time.Duration
-	expiryAction    ExpiryAction
-	ignoreLocalhost bool
-	ignoreHosts     []string
-	requestHook     RequestHook
-	responseHook    ResponseHook
+	path              string
+	cassetteExtension string
+	mode              RecordMode
+	security          SecurityConfig
+	matchers          []Matcher
+	ignoreJSONPaths   []string
+	uriNormalizer     func(string) string
+	maxAge            *time.Duration
+	expiryAction      ExpiryAction
+	ignoreLocalhost   bool
+	ignoreHosts       []string
+	requestHook       RequestHook
+	responseHook      ResponseHook
 }
 
-// WithPath sets the cassette path. A .toml extension selects TOML; other extensions use YAML.
+// WithPath sets the cassette path. A .toml extension selects TOML; other cassette extensions use YAML.
+// Names without .yaml, .yml, or .toml pick up WithCassetteExtension (default yaml).
 func WithPath(path string) Option {
 	return optionFunc(func(config *transportConfig) {
 		config.path = path
+	})
+}
+
+// WithCassetteExtension sets the suffix used when the cassette path has no cassette format.
+// Allowed values are yaml, yml, and toml.
+func WithCassetteExtension(extension string) Option {
+	return optionFunc(func(config *transportConfig) {
+		config.cassetteExtension = extension
 	})
 }
 
@@ -120,10 +130,11 @@ func NewTransport(base http.RoundTripper, options ...Option) *Transport {
 		base = http.DefaultTransport
 	}
 	config := transportConfig{
-		mode:         RecordModeOnce,
-		security:     DefaultSecurityConfig(),
-		matchers:     []Matcher{MatcherMethod, MatcherURI},
-		expiryAction: ExpiryWarn,
+		mode:              RecordModeOnce,
+		cassetteExtension: "yaml",
+		security:          DefaultSecurityConfig(),
+		matchers:          []Matcher{MatcherMethod, MatcherURI},
+		expiryAction:      ExpiryWarn,
 	}
 	for _, option := range options {
 		option.apply(&config)

--- a/go/transport_state.go
+++ b/go/transport_state.go
@@ -12,6 +12,13 @@ func (t *Transport) load() {
 		t.initErr = errors.New("cassetter: WithPath requires a cassette path")
 		return
 	}
+	extension, err := normalizeCassetteExtension(t.config.cassetteExtension)
+	if err != nil {
+		t.initErr = err
+		return
+	}
+	t.config.cassetteExtension = extension
+	t.config.path = applyCassetteExtension(t.config.path, extension)
 	switch t.config.mode {
 	case RecordModeNone, RecordModeOnce, RecordModeNewEpisodes, RecordModeAll, RecordModeRewrite:
 	default:

--- a/src/cassetter/_types.py
+++ b/src/cassetter/_types.py
@@ -20,6 +20,7 @@ class CassetteConfig(TypedDict, total=False):
     filter_replacement: str
     cassette_dir: str
     cassette_library_dir: str
+    cassette_extension: str
     intercept: list[str]
     max_age: str
     on_expiry: str

--- a/src/cassetter/config.py
+++ b/src/cassetter/config.py
@@ -21,6 +21,29 @@ from cassetter.recording import RecordMode
 if TYPE_CHECKING:
     from cassetter._core import Matcher
 
+_CASSETTE_EXTENSIONS = frozenset({"yaml", "yml", "toml"})
+
+
+def normalize_cassette_extension(value: str) -> str:
+    """Return a canonical cassette extension (`yaml`, `yml`, or `toml`)."""
+    extension = value.lower().removeprefix(".")
+    if extension not in _CASSETTE_EXTENSIONS:
+        allowed = ", ".join(sorted(_CASSETTE_EXTENSIONS))
+        raise ValueError(f"cassette_extension must be one of {allowed}, got {value!r}")
+    return extension
+
+
+def apply_cassette_extension(path: str, extension: str) -> str:
+    """Append `extension` when `path` is not already a cassette file.
+
+    Only `.yaml`, `.yml`, and `.toml` count as a format suffix, so names that
+    contain other dots (parametrized pytest ids, for example) still get one.
+    """
+    existing = os.path.splitext(path)[1].lower().removeprefix(".")
+    if existing in _CASSETTE_EXTENSIONS:
+        return path
+    return f"{path}.{extension}"
+
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class Cassetter:
@@ -40,6 +63,7 @@ class Cassetter:
     """
 
     cassette_library_dir: str | os.PathLike[str] | None = None
+    cassette_extension: str = "yaml"
     record_mode: RecordMode | str | None = None
     match_on: list[Matcher] | None = None
     ignore_json_paths: list[str] | None = None
@@ -56,6 +80,9 @@ class Cassetter:
     before_record_response: BeforeRecordResponse | None = None
     uri_normalizer: UriNormalizer | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cassette_extension", normalize_cassette_extension(self.cassette_extension))
+
     def cassette(self, name: str | os.PathLike[str]) -> Cassette:
         """Build an unloaded cassette for `name`, resolved against `cassette_library_dir`.
 
@@ -68,6 +95,7 @@ class Cassetter:
         record_mode = RecordMode.ONCE if self.record_mode is None else self.record_mode
         library_dir = self.cassette_library_dir
         path = os.fspath(name) if library_dir is None else os.path.join(library_dir, os.fspath(name))
+        path = apply_cassette_extension(path, self.cassette_extension)
         return Cassette(
             path,
             record_mode=RecordMode.from_str(record_mode) if isinstance(record_mode, str) else record_mode,

--- a/src/cassetter/context.py
+++ b/src/cassetter/context.py
@@ -30,11 +30,12 @@ def use_cassette(
     before_record_request: BeforeRecordRequest | None = None,
     before_record_response: BeforeRecordResponse | None = None,
     uri_normalizer: UriNormalizer | None = None,
+    cassette_extension: str = "yaml",
 ) -> AbstractContextManager[Cassette]:
     """Context manager for recording/replaying HTTP interactions.
 
     Args:
-        path: Path to the cassette YAML file.
+        path: Path to the cassette file. A missing cassette extension uses `cassette_extension`.
         record_mode: Controls recording behavior.
         match_on: Fields to match on (default: ["method", "uri"]).
         ignore_json_paths: JSON paths to ignore during matching.
@@ -51,6 +52,7 @@ def use_cassette(
         before_record_response: Hook to modify or skip responses.
         uri_normalizer: Callable applied to both recorded and incoming URIs
             before comparison, e.g. to erase region or account differences.
+        cassette_extension: Format used when `path` has no `.yaml`, `.yml`, or `.toml` suffix.
 
     Returns:
         A context manager yielding the active cassette.
@@ -71,5 +73,6 @@ def use_cassette(
         before_record_request=before_record_request,
         before_record_response=before_record_response,
         uri_normalizer=uri_normalizer,
+        cassette_extension=cassette_extension,
     )
     return config.use_cassette(path)

--- a/src/cassetter/pytest_plugin/fixtures.py
+++ b/src/cassetter/pytest_plugin/fixtures.py
@@ -17,7 +17,7 @@ from cassetter._state import (
 )
 from cassetter._types import CassetteConfig
 from cassetter.cassette import Cassette
-from cassetter.config import Cassetter
+from cassetter.config import Cassetter, apply_cassette_extension
 from cassetter.intercept._base import InterceptorProtocol
 from cassetter.intercept._registry import resolve_interceptors
 from cassetter.pytest_plugin.orphans import loaded_cassettes
@@ -52,7 +52,7 @@ def _split_config(vcr_config: CassetteConfig | Cassetter) -> tuple[Cassetter, st
 
 
 def _sanitized_file_name(node_name: str) -> str:
-    """The cassette file name pytest-recording derives from `node_name`.
+    """The cassette stem pytest-recording derives from `node_name`.
 
     Parametrize ids may contain characters that are forbidden in file names
     (e.g. ':' from model names), so cassettes recorded under vcrpy only resolve
@@ -60,7 +60,7 @@ def _sanitized_file_name(node_name: str) -> str:
     """
     for ch in "<>?%*:|\"'/\\":
         node_name = node_name.replace(ch, "-")
-    return node_name + ".yaml"
+    return node_name
 
 
 def _existing_file_name(cassette_dir: str, name: str, legacy_name: str) -> str:
@@ -90,12 +90,13 @@ def _resolve_cassette(
     """Resolve cassette configuration and create a Cassette instance."""
     config, config_cassette_dir = _split_config(vcr_config)
 
+    extension = config.cassette_extension
     if marker_args:
         cassette_name = marker_args[0]
     elif default_cassette is not None:
         cassette_name = default_cassette
     else:
-        cassette_name = _sanitized_file_name(node_name)
+        cassette_name = apply_cassette_extension(_sanitized_file_name(node_name), extension)
 
     record_mode = config.record_mode or "none"
     if "record_mode" in marker_kwargs:
@@ -120,7 +121,11 @@ def _resolve_cassette(
 
     # Only a name derived from the node can be the sanitized form of a legacy one.
     if not marker_args and default_cassette is None:
-        cassette_name = _existing_file_name(cassette_dir, cassette_name, node_name + ".yaml")
+        cassette_name = _existing_file_name(
+            cassette_dir,
+            cassette_name,
+            apply_cassette_extension(node_name, extension),
+        )
 
     resolved = replace(
         config,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ def test_defaults_match_use_cassette() -> None:
     cassette = Cassetter().cassette("test.yaml")
     assert cassette.path == "test.yaml"
     assert cassette.record_mode == RecordMode.ONCE
+    assert Cassetter().cassette_extension == "yaml"
 
 
 def test_cassette_library_dir_is_joined() -> None:
@@ -110,3 +111,44 @@ def test_configuration_is_frozen() -> None:
     recorder = Cassetter(record_mode="none")
     with pytest.raises(AttributeError):
         recorder.record_mode = "all"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("extension", "expected"),
+    [
+        ("yaml", "yaml"),
+        (".yml", "yml"),
+        ("TOML", "toml"),
+    ],
+    ids=["yaml", "dot-yml", "toml-case"],
+)
+def test_cassette_extension_is_normalized(extension: str, expected: str) -> None:
+    assert Cassetter(cassette_extension=extension).cassette_extension == expected
+
+
+def test_cassette_extension_appended_when_name_has_none(tmp_path: Path) -> None:
+    cassette = Cassetter(cassette_library_dir=tmp_path, cassette_extension="toml").cassette("openai")
+    assert cassette.path == str(tmp_path / "openai.toml")
+
+
+def test_cassette_extension_keeps_an_explicit_suffix(tmp_path: Path) -> None:
+    cassette = Cassetter(cassette_library_dir=tmp_path, cassette_extension="toml").cassette("openai.yaml")
+    assert cassette.path == str(tmp_path / "openai.yaml")
+
+
+def test_cassette_extension_appended_when_name_contains_other_dots() -> None:
+    cassette = Cassetter().cassette("test_func[gpt-5.4]")
+    assert cassette.path == "test_func[gpt-5.4].yaml"
+
+
+def test_cassette_extension_rejects_unknown_values() -> None:
+    with pytest.raises(ValueError, match="cassette_extension must be one of"):
+        Cassetter(cassette_extension="json")
+
+
+def test_cassette_extension_override_applies_to_one_call(tmp_path: Path) -> None:
+    recorder = Cassetter(cassette_library_dir=tmp_path)
+    with recorder.use_cassette("openai", cassette_extension="toml") as cassette:
+        assert cassette.path == str(tmp_path / "openai.toml")
+
+    assert recorder.cassette_extension == "yaml"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -128,6 +128,43 @@ def test_resolve_cassette_default_config(tmp_path: Path) -> None:
     assert len(interceptor_classes) >= 1
 
 
+def test_resolve_cassette_uses_configured_extension(tmp_path: Path) -> None:
+    test_dir = str(tmp_path)
+    cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
+    os.makedirs(cassette_dir, exist_ok=True)
+    RustCassette().save(os.path.join(cassette_dir, "test_func.toml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=CassetteConfig(record_mode="none", cassette_dir="cassettes", cassette_extension="toml"),
+        cli_record_mode=None,
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+    )
+
+    assert os.path.basename(cassette.path) == "test_func.toml"
+
+
+def test_resolve_cassette_cassetter_extension_names_unmarked_files(tmp_path: Path) -> None:
+    test_dir = str(tmp_path)
+    cassette_dir = os.path.join(test_dir, "cassettes", "test_example")
+    os.makedirs(cassette_dir, exist_ok=True)
+    RustCassette().save(os.path.join(cassette_dir, "test_func.yml"))
+
+    cassette, _ = _resolve_cassette(
+        node_name="test_func",
+        marker_args=(),
+        marker_kwargs={},
+        vcr_config=Cassetter(cassette_extension="yml"),
+        cli_record_mode=None,
+        test_fspath=os.path.join(test_dir, "test_example.py"),
+        vcr_cassette_dir=cassette_dir,
+    )
+
+    assert os.path.basename(cassette.path) == "test_func.yml"
+
+
 def test_resolve_cassette_default_cassette_marker_names_the_file(tmp_path: Path) -> None:
     """pytest-recording spells the cassette name this way, so a migrated suite keeps working."""
     test_dir = str(tmp_path)

--- a/ts/README.md
+++ b/ts/README.md
@@ -116,8 +116,13 @@ matcher is rejected rather than silently matching everything.
 YAML by default; use a `.toml` extension for TOML. TOML loads faster and
 produces smaller files, but cannot store gRPC or WebSocket interactions.
 
+A path without `.yaml`, `.yml`, or `.toml` picks up `cassetteExtension`
+(default `yaml`):
+
 ```ts
-await useCassette("cassette.toml", async () => { ... });
+await useCassette("tests/cassettes/users", {
+  cassetteExtension: "toml",
+}, async () => { ... });
 ```
 
 ## Cassette expiry

--- a/ts/src/cassette.ts
+++ b/ts/src/cassette.ts
@@ -11,6 +11,7 @@ import { existsSync, rmSync, statSync } from "node:fs";
 
 import { native, processBody, scrubInteraction, scrubGrpcInteraction, scrubWsInteraction } from "./binding.js";
 import type { NativeCassette } from "./binding.js";
+import { applyCassetteExtension, normalizeCassetteExtension } from "./extension.js";
 import { DISCARDING_MODES, RecordMode, parseDuration } from "./recording.js";
 import { NONE_BODY, bodyToBuffer } from "./types.js";
 import type {
@@ -71,6 +72,7 @@ export interface CassetteOptions {
   maxAge?: string;
   onExpiry?: "warn" | "fail" | "rerecord";
   ignoreLocalhost?: boolean;
+  cassetteExtension?: string;
 }
 
 export class Cassette {
@@ -95,7 +97,10 @@ export class Cassette {
 
   /** Configure a cassette. Nothing is read until `load()`. */
   constructor(path: string, options: CassetteOptions = {}) {
-    this._path = path;
+    this._path = applyCassetteExtension(
+      path,
+      normalizeCassetteExtension(options.cassetteExtension ?? "yaml"),
+    );
     this._recordMode = options.recordMode ?? RecordMode.ONCE;
     this._matchConfig = options.matchConfig ?? {};
     this._securityConfig = options.securityConfig ?? {};

--- a/ts/src/context.ts
+++ b/ts/src/context.ts
@@ -68,6 +68,7 @@ export async function useCassette(
     maxAge: options.maxAge,
     onExpiry: options.onExpiry,
     ignoreLocalhost: options.ignoreLocalhost,
+    cassetteExtension: options.cassetteExtension,
   });
 
   cassette.load();

--- a/ts/src/extension.ts
+++ b/ts/src/extension.ts
@@ -1,0 +1,23 @@
+import { extname } from "node:path";
+
+const CASSETTE_EXTENSIONS = ["toml", "yaml", "yml"] as const;
+
+/** Canonical cassette suffix: `yaml`, `yml`, or `toml`. */
+export function normalizeCassetteExtension(value: string): string {
+  const extension = value.replace(/^\./, "").toLowerCase();
+  if ((CASSETTE_EXTENSIONS as readonly string[]).includes(extension)) {
+    return extension;
+  }
+  throw new Error(
+    `cassette_extension must be one of ${CASSETTE_EXTENSIONS.join(", ")}, got '${value}'`,
+  );
+}
+
+/** Append `extension` when `path` is not already a cassette file. */
+export function applyCassetteExtension(path: string, extension: string): string {
+  const existing = extname(path).replace(/^\./, "").toLowerCase();
+  if ((CASSETTE_EXTENSIONS as readonly string[]).includes(existing)) {
+    return path;
+  }
+  return `${path}.${extension}`;
+}

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -100,6 +100,7 @@ export interface CassetteConfig extends MatchConfig, SecurityConfig {
   maxAge?: string;
   onExpiry?: "warn" | "fail" | "rerecord";
   ignoreLocalhost?: boolean;
+  cassetteExtension?: string;
 }
 
 // --- Body helpers ---

--- a/ts/tests/cassette.test.ts
+++ b/ts/tests/cassette.test.ts
@@ -96,6 +96,42 @@ describe("load", () => {
   });
 });
 
+describe("cassette extension", () => {
+  it("appends yaml when the path has no cassette suffix", () => {
+    write("users.yaml");
+    const c = new Cassette(join(dir, "users"), { recordMode: RecordMode.NONE });
+    c.load();
+    expect(c.path).toBe(join(dir, "users.yaml"));
+  });
+
+  it("uses cassetteExtension for an extensionless path", () => {
+    write("users.toml", "version = 1\ninteractions = []\n");
+    const c = new Cassette(join(dir, "users"), {
+      recordMode: RecordMode.NONE,
+      cassetteExtension: "toml",
+    });
+    c.load();
+    expect(c.path).toBe(join(dir, "users.toml"));
+  });
+
+  it("keeps an explicit cassette suffix", () => {
+    const path = write("users.yaml");
+    const c = new Cassette(path, { cassetteExtension: "toml" });
+    expect(c.path).toBe(path);
+  });
+
+  it("appends when the name contains other dots", () => {
+    const c = new Cassette(join(dir, "test_func[gpt-5.4]"));
+    expect(c.path).toBe(join(dir, "test_func[gpt-5.4].yaml"));
+  });
+
+  it("rejects an unknown cassette extension", () => {
+    expect(() => new Cassette(join(dir, "users"), { cassetteExtension: "json" })).toThrow(
+      /cassette_extension/,
+    );
+  });
+});
+
 describe("record modes", () => {
   it("once replays without recording when the cassette exists", () => {
     const c = new Cassette(write("t.yaml"), { recordMode: RecordMode.ONCE });


### PR DESCRIPTION
## Summary
- Add `cassette_extension` (Python/Rust), `WithCassetteExtension` (Go), and `cassetteExtension` (TypeScript) so cassette names without `.yaml`, `.yml`, or `.toml` pick a default format (`yaml` unless configured).
- Pytest-generated cassette names honor the same setting, and an explicit suffix on a path still wins.
- Document the option across the Python, Rust, Go, and Node SDKs.

## Test plan
- [ ] `uv run pytest tests/test_config.py tests/test_plugin.py -q --no-cov`
- [ ] `cargo test -p cassetter-core cassette::extension_tests` and `cargo test -p cassetter config::tests`
- [ ] `go test ./... -count=1 -run 'TestTransport(AppliesDefaultCassetteExtension|CassetteExtension)'` in `go/`
- [ ] `npx vitest run tests/cassette.test.ts` in `ts/` (after native build)


Made with [Cursor](https://cursor.com)