### PR TITLE
Defer cassette persistence until Recorder::finish

### DIFF
--- a/crates/cassetter/Cargo.toml
+++ b/crates/cassetter/Cargo.toml
@@ -52,3 +52,8 @@ tower = { version = "0.5", features = ["util"] }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "recorder_persist"
+harness = false
+required-features = ["reqwest"]

--- a/crates/cassetter/README.md
+++ b/crates/cassetter/README.md
@@ -76,8 +76,9 @@ Each `Recorder` owns independent playback state. Clone one recorder to share a
 cassette safely across concurrent tasks. Build separate recorders when tests
 must not consume each other's interactions.
 
-Always call `Recorder::finish`. It saves an empty replacement cassette when
-needed and reports persistence failures or calls cancelled while recording.
+Always call `Recorder::finish`. It writes the cassette once (including an empty
+replacement when needed) and reports persistence failures or calls cancelled
+while recording.
 
 ## Current limits
 

--- a/crates/cassetter/benches/recorder_persist.rs
+++ b/crates/cassetter/benches/recorder_persist.rs
@@ -1,0 +1,141 @@
+//! Wall-clock cost of recording N HTTP interactions through [`cassetter::Recorder`].
+//!
+//! This is the path that used to rewrite the cassette file after every
+//! response. Run with `cargo bench -p cassetter --bench recorder_persist`.
+
+#![allow(clippy::print_stdout)]
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use cassetter::{RecordMode, Recorder};
+use reqwest::{Method, Request, Url};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const ITERATIONS: usize = 8;
+const TRIM: usize = 2;
+const SCALES: &[usize] = &[10, 100, 1000];
+
+#[tokio::main]
+async fn main() {
+    println!("cassetter recorder persist");
+    println!("iterations: {ITERATIONS} (trimmed mean, drop {TRIM} extremes)");
+    println!();
+    println!(
+        "  {:<8}{:>16}{:>18}",
+        "n", "record+finish", "save-once (core)"
+    );
+
+    for &n in SCALES {
+        let recorder = bench_async(|| record_n(n)).await;
+        let core = bench(|| save_once(n));
+        println!("  {n:<8}{:>16}{:>18}", fmt(recorder), fmt(core));
+    }
+}
+
+fn bench(mut run: impl FnMut()) -> Duration {
+    let mut times = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let start = Instant::now();
+        run();
+        times.push(start.elapsed());
+    }
+    trimmed_mean(&mut times)
+}
+
+async fn bench_async<F, Fut>(mut run: F) -> Duration
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut times = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let start = Instant::now();
+        run().await;
+        times.push(start.elapsed());
+    }
+    trimmed_mean(&mut times)
+}
+
+fn trimmed_mean(times: &mut [Duration]) -> Duration {
+    times.sort();
+    let kept = &times[TRIM / 2..times.len() - TRIM / 2];
+    kept.iter().sum::<Duration>() / kept.len() as u32
+}
+
+fn fmt(duration: Duration) -> String {
+    let ms = duration.as_secs_f64() * 1000.0;
+    if ms >= 1.0 {
+        format!("{ms:.2} ms")
+    } else {
+        format!("{:.1} us", ms * 1000.0)
+    }
+}
+
+async fn record_n(n: usize) {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("bench.yaml");
+    let (url, server) = n_response_server(n).await;
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    for i in 0..n {
+        let request = Request::new(Method::GET, url.join(&format!("/items/{i}")).unwrap());
+        client.execute(request).await.unwrap();
+    }
+    recorder.finish().await.unwrap();
+    server.await.unwrap();
+}
+
+fn save_once(n: usize) {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("bench.yaml");
+    let mut cassette = cassetter_core::cassette::Cassette::new();
+    for i in 0..n {
+        cassette.add_interaction(interaction(i));
+    }
+    cassette.save(path.to_str().unwrap(), None, None).unwrap();
+}
+
+fn interaction(i: usize) -> cassetter_core::protocol::http::HttpInteraction {
+    use cassetter_core::protocol::http::{Body, HttpInteraction, HttpRequest, HttpResponse};
+
+    HttpInteraction::new(
+        HttpRequest::new(
+            "GET".to_string(),
+            format!("https://api.example.com/items/{i}"),
+            None,
+            Some(Body::json(serde_json::json!({"query": i}))),
+        ),
+        HttpResponse::new(
+            200,
+            None,
+            Some(Body::json(
+                serde_json::json!({"id": i, "name": format!("item-{i}")}),
+            )),
+        ),
+        "2026-01-01T00:00:00Z".to_string(),
+    )
+}
+
+async fn n_response_server(n: usize) -> (Url, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        for i in 0..n {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            let body = format!(r#"{{"id":{i}}}"#);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    (Url::parse(&format!("http://{address}")).unwrap(), server)
+}

--- a/crates/cassetter/src/recorder.rs
+++ b/crates/cassetter/src/recorder.rs
@@ -43,16 +43,19 @@ impl Recorder {
 
     /// Persist the cassette and report every failed or incomplete recording.
     ///
-    /// Call this after all clients that share the recorder have finished.
+    /// Recorded interactions stay in memory until this call, so a suite of N
+    /// requests pays for one YAML write instead of N growing rewrites. Call
+    /// this after all clients that share the recorder have finished.
     pub async fn finish(&self) -> Result<()> {
-        let save_empty = {
+        let should_save = {
             let mut state = self.lock()?;
-            let save_empty = !state.finalized && state.save_empty;
+            let should_save = !state.finalized && (state.dirty || state.save_empty);
             state.finalized = true;
-            save_empty
+            state.dirty = false;
+            should_save
         };
 
-        if save_empty {
+        if should_save {
             if let Err(error) = self.save() {
                 self.remember_error(error.to_string())?;
             }
@@ -140,8 +143,9 @@ impl Recorder {
             state.cassette.insert_interaction(position, interaction)?;
             state.pending.remove(&order);
             state.save_empty = false;
+            state.dirty = true;
         }
-        self.save().map_err(|error| self.recording_error(error))
+        Ok(())
     }
 
     #[cfg(feature = "tonic")]
@@ -157,8 +161,9 @@ impl Recorder {
                 .insert_grpc_interaction(position, interaction)?;
             state.pending.remove(&order);
             state.save_empty = false;
+            state.dirty = true;
         }
-        self.save().map_err(|error| self.recording_error(error))
+        Ok(())
     }
 
     #[cfg(any(feature = "reqwest", feature = "tonic"))]
@@ -167,13 +172,6 @@ impl Recorder {
         state.pending.remove(&order);
         state.errors.push(error.to_string());
         Ok(())
-    }
-
-    #[cfg(any(feature = "reqwest", feature = "tonic"))]
-    fn recording_error(&self, error: Error) -> Error {
-        let message = error.to_string();
-        let _ = self.remember_error(message.clone());
-        Error::Recording(vec![message])
     }
 
     fn remember_error(&self, error: String) -> Result<()> {

--- a/crates/cassetter/src/recorder_state.rs
+++ b/crates/cassetter/src/recorder_state.rs
@@ -34,6 +34,10 @@ pub(crate) struct State {
     pub(crate) pending: BTreeMap<usize, String>,
     pub(crate) errors: Vec<String>,
     pub(crate) save_empty: bool,
+    /// Unpersisted recordings. `finish` writes the cassette once instead of
+    /// rewriting the file after every interaction.
+    #[cfg_attr(not(any(feature = "reqwest", feature = "tonic")), allow(dead_code))]
+    pub(crate) dirty: bool,
     pub(crate) file_mode: Option<u32>,
     pub(crate) finalized: bool,
 }
@@ -75,6 +79,7 @@ impl State {
             pending: BTreeMap::new(),
             errors: Vec::new(),
             save_empty: exists && builder.mode == RecordMode::All,
+            dirty: false,
             file_mode: preserved_mode,
             finalized: false,
         })

--- a/crates/cassetter/tests/http.rs
+++ b/crates/cassetter/tests/http.rs
@@ -223,6 +223,32 @@ async fn concurrent_recorders_keep_cassettes_isolated() {
 }
 
 #[tokio::test]
+async fn cassette_is_written_only_on_finish() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("deferred.yaml");
+    let (url, server) = one_response_server("body").await;
+    let recorder = Recorder::builder(&path)
+        .record_mode(RecordMode::All)
+        .build()
+        .unwrap();
+    let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
+    assert_eq!(
+        client
+            .execute(Request::new(Method::GET, url))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap(),
+        "body"
+    );
+    assert!(!path.exists());
+    recorder.finish().await.unwrap();
+    server.await.unwrap();
+    assert!(std::fs::read_to_string(path).unwrap().contains("body"));
+}
+
+#[tokio::test]
 async fn finalization_reports_a_save_error() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("cassette.yaml");
@@ -233,12 +259,11 @@ async fn finalization_reports_a_save_error() {
         .build()
         .unwrap();
     let client = cassetter::reqwest::Client::new(reqwest::Client::new(), recorder.clone());
-
-    let error = client
+    let response = client
         .execute(Request::new(Method::GET, url))
         .await
-        .unwrap_err();
-    assert!(matches!(error, Error::Recording(_)));
+        .unwrap();
+    assert_eq!(response.text().await.unwrap(), "response");
     let error = recorder.finish().await.unwrap_err();
     assert!(matches!(error, Error::Recording(_)));
     let error = recorder.finish().await.unwrap_err();


### PR DESCRIPTION
## Summary

- The Rust `Recorder` used to rewrite the cassette file after every recorded HTTP/gRPC interaction. That made re-recording **quadratic** in cassette size (serialize the growing YAML on each append).
- Recorded interactions now stay in memory and are written **once** in `Recorder::finish`, matching the Python fixture teardown path.
- Persistence failures surface on `finish` instead of on `execute`. A crash before `finish` no longer leaves a partial cassette on disk.

Measured with `cargo bench -p cassetter --bench recorder_persist` (trimmed mean, 8 runs):

| n | save after each request | save on `finish` | speedup |
|---|---|---|---|
| 10 | 15.64 ms | 7.11 ms | 2.2× |
| 100 | 160.89 ms | 68.00 ms | 2.4× |
| 1000 | 4903.14 ms | 666.68 ms | 7.4× |

Python `load`/`match`/`save` benches are unchanged; they already persist once per cassette.

## Test plan

- [x] `cargo test -p cassetter`
- [x] `cargo bench -p cassetter --bench recorder_persist` (before/after)
- [ ] Confirm `Recorder::finish` is still called in existing Rust examples and tests
- [ ] Re-record a large cassette through the reqwest/tonic wrapper and confirm the file appears only after `finish`


Made with [Cursor](https://cursor.com)